### PR TITLE
Use Shadow DOM for style encapsulation

### DIFF
--- a/src/ShadowDOMWrapper.jsx
+++ b/src/ShadowDOMWrapper.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import { Theme } from "@radix-ui/themes";
+import './styles/index.css';  // Import app styles (including Tailwind)
+
+const ShadowDOMWrapper = () => {
+  const hostRef = useRef(null);
+  const shadowRootRef = useRef(null);
+  const rootRef = useRef(null);
+
+  useEffect(() => {
+    if (hostRef.current && !shadowRootRef.current) {
+      // Create shadow root
+      shadowRootRef.current = hostRef.current.attachShadow({ mode: 'open' });
+
+      // Create a container for React content
+      const container = document.createElement('div');
+      container.id = 'shadow-root';
+      shadowRootRef.current.appendChild(container);
+
+      // Add required stylesheets
+      const stylesheets = [
+        { href: '/base-unit-tools.css', id: 'bundled-styles' }, // Bundled styles
+        { href: 'https://unpkg.com/@radix-ui/themes@3.1.4/styles.css', id: 'radix-styles' },
+        { href: 'https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.css', id: 'maplibre-styles' }
+      ];
+
+      stylesheets.forEach(({ href, id }) => {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+        link.id = id;
+        shadowRootRef.current.appendChild(link);
+      });
+
+      // Create root and render app
+      rootRef.current = createRoot(container);
+      rootRef.current.render(
+        <React.StrictMode>
+          <Theme accentColor="green" grayColor="sand" radius="small" scaling="100%">
+            <App mode={'embedded'} basePath={''}
+            />
+          </Theme>
+        </React.StrictMode>
+      );
+    }
+
+    return () => {
+      if (rootRef.current) {
+        rootRef.current.unmount();
+      }
+    };
+  });
+
+  return <div ref={hostRef} className="base-unit-tools-container" />;
+};
+
+// Modified initialization function
+export const initEmbeddedBaseUnitTools = (elementId) => {
+  const container = document.getElementById(elementId);
+  if (!container) {
+    console.error(`Container with id "${elementId}" not found`);
+    return;
+  }
+
+  const root = createRoot(container);
+  root.render(<ShadowDOMWrapper />);
+};
+
+// Export for use in embedded-index.js
+export default initEmbeddedBaseUnitTools;

--- a/src/embedded-index.js
+++ b/src/embedded-index.js
@@ -1,5 +1,5 @@
-import { initBaseUnitTools } from './index.jsx';
+import { initEmbeddedBaseUnitTools } from './ShadowDOMWrapper';
 
-initBaseUnitTools('root', { 
-  mode: 'embedded',
-});
+if (document.getElementById('root')) {
+  initEmbeddedBaseUnitTools('root');
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,14 +7,14 @@ import "@radix-ui/themes/styles.css";
 import { Theme } from "@radix-ui/themes";
 
 // Function to initialize the app
-export function initBaseUnitTools(elementId, options = {}) {
+function initStandaloneBaseUnitTools(elementId) {
   const root = createRoot(document.getElementById(elementId));
   root.render(
     <React.StrictMode>
       <Theme accentColor="green" grayColor="sand" radius="small" scaling="100%">
         <App
-          mode={options.mode || 'embedded'}
-          basePath={options.basePath || ''}
+          mode={'standalone'}
+          basePath={''}
         />
       </Theme>
     </React.StrictMode>
@@ -23,5 +23,5 @@ export function initBaseUnitTools(elementId, options = {}) {
 
 // If running standalone
 if (document.getElementById('root')) {
-  initBaseUnitTools('root', { mode: 'standalone' });
+  initStandaloneBaseUnitTools('root');
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,14 @@ const embeddedConfig = {
       output: {
         format: 'es',
         entryFileNames: 'base-unit-tools.js',
+        assetFileNames: (assetInfo) => {
+          // Ensure CSS files are named predictably
+          if (assetInfo.name.endsWith('.css')) {
+            return 'base-unit-tools.css';
+          }
+          // Other assets can use a hash
+          return 'assets/[name]-[hash][extname]';
+        }
       }
     },
     cssCodeSplit: false


### PR DESCRIPTION
## Part of CityOfDetroit/data-engineering#2668, CityOfDetroit/detroitmi#1759

Generally speaking, we have to make additional changes to prepare this webapp to be embedded on an existing website, HTML document, and browser.

## Changes in this PR

1. Encapsulate the webapp inside a [Shadow DOM](https://javascript.info/shadow-dom) to avoid the styles of detroitmi.gov affecting the web app and vice-versa (as mentioned in #53)
2. Copy over stylesheets from regular DOM into the shadow DOM

This approach addresses the style conflicts we saw in CityOfDetroit/detroitmi#1775. 

## Testing

Make sure the standalone webapp version and the embedded webapp version both are styled the same and have the same functionality.


https://github.com/user-attachments/assets/a2690c9e-94bc-44e0-b397-bc0928c2470f