### PR TITLE
Fix streetview for embedding in ShadowDOM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "base-unit-tools-two",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "base-unit-tools-two",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@arcgis/core": "^4.30.9",
         "@arcgis/map-components-react": "^4.30.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-unit-tools-two",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "dependencies": {
     "@arcgis/core": "^4.30.9",

--- a/src/Map/Mapillary.jsx
+++ b/src/Map/Mapillary.jsx
@@ -5,7 +5,7 @@ import distance from "@turf/distance";
 import { SimpleMarker, Viewer } from "mapillary-js";
 import "mapillary-js/dist/mapillary.css";
 import moment from "moment";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import _ from "underscore";
 import { DataSource } from "../components/CardLink";
 
@@ -81,10 +81,12 @@ const Mapillary = ({
 
   let [center, setCenter] = useState(null);
 
+  let mlyViewerRef = useRef(null);
+
   useEffect(() => {
     const viewer = new Viewer({
       accessToken: "MLY|4690399437648324|de87555bb6015affa20c3df794ebab15",
-      container: "mly-viewer",
+      container: mlyViewerRef.current,
       component: {
         marker: true,
         bearing: false,
@@ -95,7 +97,7 @@ const Mapillary = ({
         direction: true,
       },
       imageId: null,
-    });
+    }, [mlyViewerRef]);
 
     viewer.deactivateCover();
 
@@ -224,6 +226,7 @@ const Mapillary = ({
       <div
         className="w-full sm:w-2/3 lg:w-3/4 rounded-md min-h-72"
         id="mly-viewer"
+        ref={mlyViewerRef}
       ></div>
 
       <Card size={"1"} className="w-full sm:w-1/3 lg:w-1/4">


### PR DESCRIPTION
## What is wrong with street view?

It looks like the Mapillary Viewer is unable to find the `mly-viewer` div [here](https://github.com/CityOfDetroit/base-unit-tools/blob/637d4789a3e91a9ec7f4b56c04ec4c076ded0421/src/Map/Mapillary.jsx#L87). 

https://github.com/user-attachments/assets/25ddb6da-a9c1-4d42-95aa-95065b190bff

```
Error: Container "mly-viewer" not found.
```

This is probably because, under the hood, the Mapillary Viewer implementation tries to search the lightDOM for the HTML element, but in [base-unit-tools#54](https://github.com/CityOfDetroit/base-unit-tools/pull/54) we moved the web app into a ShadowDOM. 

## How do we fix it?

The fix here would be to pass an [HTMLDivElement directly to the Viewer options](https://mapillary.github.io/mapillary-js/docs/main/init#viewer-options) in the `useEffect` by using [`useRef`](https://react.dev/reference/react/useRef#manipulating-the-dom-with-a-ref) to reference the `mly-viewer` div in React. That should eliminate the need for Mapillary to try to query the lightDOM (or any DOM) for the HTMLElement.

## This PR

- Replace the div ID with an HTMLDivElement using references in React to manipulate the DOM

## Testing

Check that streetview works in my local environment when embedding the app.


https://github.com/user-attachments/assets/2c6a2bed-bd25-4eb9-bd74-d66addd6d319

