### PR TITLE
Add Zoning Amendments editor app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "base-unit-tools",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "base-unit-tools",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "dependencies": {
         "@arcgis/core": "^4.30.9",
         "@esri/arcgis-rest-feature-service": "^4.0.6",
@@ -27,6 +27,7 @@
         "@turf/difference": "^7.1.0",
         "@turf/distance": "^7.1.0",
         "@turf/simplify": "^7.1.0",
+        "@turf/union": "^7.3.5",
         "bluebird": "^3.7.2",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^4.7.1",
@@ -3160,13 +3161,13 @@
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
-      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
-        "tslib": "^2.6.2"
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -3196,13 +3197,14 @@
       }
     },
     "node_modules/@turf/meta": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
-      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "^7.1.0",
-        "@types/geojson": "^7946.0.10"
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -3236,6 +3238,22 @@
         "@turf/meta": "^7.1.0",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.5.tgz",
+      "integrity": "sha512-/FSKhl+LX4+M7L/Trmiln0CDPWS8vCneGnQktt1o5XbCY/zIpH1JdxHEBFXhFZg4beAyXCz0uuxRyW9N/DH+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
@@ -3901,6 +3919,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -7492,6 +7519,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/polygon-clipping": {
       "version": "0.15.7",
       "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
@@ -8441,6 +8478,12 @@
       "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
       "license": "MIT"
     },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
+    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -8832,9 +8875,10 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@turf/difference": "^7.1.0",
     "@turf/distance": "^7.1.0",
     "@turf/simplify": "^7.1.0",
+    "@turf/union": "^7.3.5",
     "bluebird": "^3.7.2",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^4.7.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import Login from "./Login";
 const BaseUnitsMap = lazy(() => import("./Map/BaseUnitsMap"));
 const Geocoder = lazy(() => import("./Geocoder/Geocoder"));
 const Mailer = lazy(() => import("./Mailer/Mailer"));
+const Zoning = lazy(() => import("./Zoning/Zoning"));
 const About = lazy(() => import("./About"));
 const BaseUnitPage = lazy(() => import("./BaseUnitPage"));
 
@@ -40,6 +41,7 @@ const App = () => {
                 <Route path="/map" element={<BaseUnitsMap />} />
                 <Route path="/geocoder" element={<Geocoder />} />
                 <Route path="/mailer" element={<ProtectedRoute path="/mailer"><Mailer /></ProtectedRoute>} />
+                <Route path="/zoning" element={<ProtectedRoute path="/zoning"><Zoning /></ProtectedRoute>} />
                 <Route path="/base-unit/:unit" element={<BaseUnitPage />} />
               </Routes>
             </Suspense>

--- a/src/Homepage.jsx
+++ b/src/Homepage.jsx
@@ -91,13 +91,39 @@ const useFeatureCount = (endpoint) => {
 };
 
 const Homepage = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isInGroup } = useAuth();
   const [chromeNoticeOpen, setChromeNoticeOpen] = useState(false);
 
   const addresses = useFeatureCount(layers.address.endpoint);
   const buildings = useFeatureCount(layers.building.endpoint);
   const parcels = useFeatureCount(layers.parcel.endpoint);
   const streets = useFeatureCount(layers.street.endpoint);
+
+  // apps the current user can see, split into general vs. access-gated
+  const visibleApps = Object.keys(apps)
+    .slice(1)
+    .filter((app) => {
+      if (apps[app].private && !isAuthenticated) return false;
+      if (apps[app].group && !isInGroup(apps[app].group)) return false;
+      return true;
+    });
+  const isRestricted = (app) => apps[app].private || apps[app].group;
+  const publicApps = visibleApps.filter((app) => !isRestricted(app));
+  const accessibleApps = visibleApps.filter(isRestricted);
+
+  const renderAppCard = (app) => (
+    <Link to={apps[app].url} key={app}>
+      <Card size="1" className="text-sm">
+        <Flex direction="row" align="center" gap="2" pb="2">
+          <Icon name={apps[app].icon} />
+          <Text size="3" weight="medium">
+            {apps[app].name}
+          </Text>
+        </Flex>
+        <Text>{apps[app].description}</Text>
+      </Card>
+    </Link>
+  );
 
   return (
     <div className="bg-gray-100 dark:bg-gray-800">
@@ -117,54 +143,50 @@ const Homepage = () => {
           </Link>
         </Box>
 
-        <Box
-          mb="5"
-          className="rounded-md overflow-hidden"
-          style={{ backgroundColor: "#004445" }}
-        >
-          <Box className="p-4">
-            <Flex gap="3" align="start">
-              <InfoCircledIcon
-                width="20"
-                height="20"
-                style={{ color: "#feb70d", flexShrink: 0, marginTop: "2px" }}
-              />
-              <Text size="2" style={{ color: "#f2f2f2" }}>
-                <Text as="span" weight="medium" style={{ color: "#feb70d" }}>
-                  City employees:
-                </Text>{" "}
-                You will need to sign in with <Link to="https://detroitmi.maps.arcgis.com">ArcGIS Online</Link> to access employee-only
-                tools.
-              </Text>
-            </Flex>
-          </Box>
-        </Box>
-
         <Box mb="5">
           <Heading size="4" mb="3">
             Tools available on this site
           </Heading>
           <Grid columns={{ initial: "1", sm: "2" }} gap="4">
-            {Object.keys(apps)
-              .slice(1)
-              .map((app) => {
-                if (apps[app].private && !isAuthenticated) return null;
-                return (
-                  <Link to={apps[app].url} key={app}>
-                    <Card size="1" className="text-sm">
-                      <Flex direction="row" align="center" gap="2" pb="2">
-                        <Icon name={apps[app].icon} />
-                        <Text size="3" weight="medium">
-                          {apps[app].name}
-                        </Text>
-                      </Flex>
-                      <Text>{apps[app].description}</Text>
-                    </Card>
-                  </Link>
-                );
-              })}
+            {publicApps.map(renderAppCard)}
           </Grid>
         </Box>
+
+        {!isAuthenticated && (
+          <Box
+            mb="5"
+            className="rounded-md overflow-hidden"
+            style={{ backgroundColor: "#004445" }}
+          >
+            <Box className="p-4">
+              <Flex gap="3" align="start">
+                <InfoCircledIcon
+                  width="20"
+                  height="20"
+                  style={{ color: "#feb70d", flexShrink: 0, marginTop: "2px" }}
+                />
+                <Text size="2" style={{ color: "#f2f2f2" }}>
+                  <Text as="span" weight="medium" style={{ color: "#feb70d" }}>
+                    City employees:
+                  </Text>{" "}
+                  You will need to sign in with <Link to="https://detroitmi.maps.arcgis.com">ArcGIS Online</Link> to access employee-only
+                  tools.
+                </Text>
+              </Flex>
+            </Box>
+          </Box>
+        )}
+
+        {accessibleApps.length > 0 && (
+          <Box mb="5">
+            <Heading size="4" mb="3">
+              Tools accessible to you
+            </Heading>
+            <Grid columns={{ initial: "1", sm: "2" }} gap="4">
+              {accessibleApps.map(renderAppCard)}
+            </Grid>
+          </Box>
+        )}
 
         <Box pb="5">
           <Heading size="4" mb="3">

--- a/src/Zoning/AmendmentCardList.jsx
+++ b/src/Zoning/AmendmentCardList.jsx
@@ -1,0 +1,119 @@
+import { Box, Button, Flex, Select, Text } from "@radix-ui/themes";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  PlusIcon,
+} from "@radix-ui/react-icons";
+import { SORT_OPTIONS, deriveStatus, fmtDate } from "../data/zoning";
+
+// Scrollable, sortable list of amendment cards.
+const AmendmentCardList = ({
+  records,
+  loading,
+  selectedId,
+  sortField,
+  sortDir,
+  onSortField,
+  onToggleDir,
+  onSelect,
+  onNew,
+}) => {
+  return (
+    <Flex direction="column" gap="2" style={{ height: "80vh", minHeight: 0 }}>
+      <Flex justify="between" align="center">
+        <Text size="5" weight="bold" className="text-[#004445]">
+          Zoning Amendments
+        </Text>
+        <Button onClick={onNew} style={{ backgroundColor: "#004445" }}>
+          <PlusIcon /> New
+        </Button>
+      </Flex>
+
+      <Flex gap="2" align="center">
+        <Text size="1" color="gray">
+          Sort by
+        </Text>
+        <Select.Root value={sortField} onValueChange={onSortField}>
+          <Select.Trigger />
+          <Select.Content>
+            {SORT_OPTIONS.map((o) => (
+              <Select.Item key={o.value} value={o.value}>
+                {o.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+        <Button
+          size="1"
+          variant="soft"
+          onClick={onToggleDir}
+          title={sortDir === "asc" ? "Ascending" : "Descending"}
+        >
+          {sortDir === "asc" ? <ArrowUpIcon /> : <ArrowDownIcon />}
+        </Button>
+      </Flex>
+
+      <Box style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+        <Flex direction="column" gap="2" pr="2">
+          {loading && (
+            <Text size="2" color="gray">
+              Loading…
+            </Text>
+          )}
+          {!loading && records.length === 0 && (
+            <Text size="2" color="gray">
+              No amendments found.
+            </Text>
+          )}
+          {records.map((a) => {
+            const selected = a.OBJECTID === selectedId;
+            return (
+              <Box
+                key={a.OBJECTID}
+                onClick={() => onSelect(a)}
+                className="cursor-pointer rounded-md border p-3 transition-colors"
+                style={{
+                  borderColor: selected ? "var(--accent-8)" : "var(--gray-a5)",
+                  backgroundColor: selected ? "var(--accent-a3)" : "transparent",
+                }}
+              >
+                <Flex justify="between" align="start" gap="2">
+                  <Box>
+                    <Text weight="bold" size="2" as="div">
+                      {a.file_number || `Record ${a.OBJECTID}`}
+                    </Text>
+                    {a.application_type && (
+                      <Text size="1" color="gray" as="div">
+                        {a.application_type}
+                      </Text>
+                    )}
+                  </Box>
+                  {a.received_date && (
+                    <Text size="1" color="gray" className="whitespace-nowrap">
+                      {fmtDate(a.received_date)}
+                    </Text>
+                  )}
+                </Flex>
+                {(a.current_zoning || a.proposed_zoning) && (
+                  <Text size="1" color="gray" className="block mt-1">
+                    {a.current_zoning || "?"} → {a.proposed_zoning || "?"}
+                  </Text>
+                )}
+                <Flex justify="between" align="center" gap="2" className="mt-1">
+                  <Text size="1">{deriveStatus(a)}</Text>
+                  {a.assigned_to && (
+                    <Text size="1" color="gray" className="whitespace-nowrap">
+                      {a.assigned_to}
+                    </Text>
+                  )}
+                </Flex>
+              </Box>
+            );
+          })}
+        </Flex>
+      </Box>
+    </Flex>
+  );
+};
+
+export default AmendmentCardList;

--- a/src/Zoning/AmendmentMiniMap.jsx
+++ b/src/Zoning/AmendmentMiniMap.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import maplibregl from "maplibre-gl";
+import bbox from "@turf/bbox";
+import { baseStyle } from "../styles/mapstyle.js";
+
+// Small read-only map that displays a single amendment's saved geometry.
+const AmendmentMiniMap = ({ geometry, height = "300px" }) => {
+  const containerRef = useRef(null);
+  const [theMap, setTheMap] = useState(null);
+
+  useEffect(() => {
+    const detroitBbox = [-83.287803, 42.255192, -82.910451, 42.45023];
+    const map = new maplibregl.Map({
+      container: containerRef.current,
+      style: baseStyle,
+      bounds: detroitBbox,
+    });
+
+    map.on("load", () => {
+      map.resize();
+
+      // static map: keep it from being panned/zoomed (mouse events still fire)
+      map.dragPan.disable();
+      map.scrollZoom.disable();
+      map.boxZoom.disable();
+      map.dragRotate.disable();
+      map.doubleClickZoom.disable();
+      map.touchZoomRotate.disable();
+      map.keyboard.disable();
+
+      map.addSource("amendment", {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+      map.addLayer({
+        id: "amendment-fill",
+        type: "fill",
+        source: "amendment",
+        paint: { "fill-color": "#2563eb", "fill-opacity": 0.3 },
+      });
+      map.addLayer({
+        id: "amendment-line",
+        type: "line",
+        source: "amendment",
+        paint: { "line-color": "#1d4ed8", "line-width": 2 },
+      });
+
+      // hover tooltip showing the underlying parcel id
+      const popup = new maplibregl.Popup({
+        closeButton: false,
+        closeOnClick: false,
+        offset: 8,
+        className: "zoning-parcel-tip",
+      });
+      map.on("mousemove", "parcel-fill", (e) => {
+        const pid = e.features?.[0]?.properties?.parcel_id;
+        if (!pid) {
+          popup.remove();
+          return;
+        }
+        map.getCanvas().style.cursor = "crosshair";
+        popup.setLngLat(e.lngLat).setText(String(pid)).addTo(map);
+      });
+      map.on("mouseleave", "parcel-fill", () => {
+        map.getCanvas().style.cursor = "";
+        popup.remove();
+      });
+
+      setTheMap(map);
+    });
+
+    return () => map.remove();
+  }, []);
+
+  useEffect(() => {
+    if (!theMap) return;
+    const src = theMap.getSource("amendment");
+    if (!src) return;
+    if (geometry) {
+      src.setData(geometry);
+      try {
+        theMap.fitBounds(bbox(geometry), {
+          padding: 30,
+          maxZoom: 18,
+          animate: false,
+        });
+      } catch (e) {
+        /* ignore degenerate bounds */
+      }
+    } else {
+      src.setData({ type: "FeatureCollection", features: [] });
+    }
+  }, [theMap, geometry]);
+
+  return <div ref={containerRef} style={{ height, minHeight: "200px" }} />;
+};
+
+export default AmendmentMiniMap;

--- a/src/Zoning/AmendmentView.jsx
+++ b/src/Zoning/AmendmentView.jsx
@@ -1,0 +1,295 @@
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Grid,
+  Spinner,
+  Text,
+} from "@radix-ui/themes";
+import {
+  ArrowLeftIcon,
+  CheckCircledIcon,
+  Cross2Icon,
+  ExclamationTriangleIcon,
+  ExternalLinkIcon,
+  Pencil1Icon,
+} from "@radix-ui/react-icons";
+import {
+  FIELD_BY_NAME,
+  FIELD_GROUPS,
+  ZONING_FIELDS,
+  fmtDate,
+  parcelMapUrl,
+  parseParcels,
+} from "../data/zoning";
+import FieldInput from "./FieldInput";
+import ParcelSearch from "./ParcelSearch";
+import ParcelSelectionPanel from "./ParcelSelectionPanel";
+import ZoningMap from "./ZoningMap";
+import AmendmentMiniMap from "./AmendmentMiniMap";
+
+// Fields shown above the map; the rest render in the details grid.
+const TOP_FIELDS = ["application_type", "application_description"];
+const MAP_HEIGHT = "360px";
+
+// Read-only rendering of a field, mirroring FieldInput's label markup.
+const ReadField = ({ field, value }) => {
+  const display =
+    field.type === "date" ? fmtDate(value) : value == null ? "" : String(value);
+  return (
+    <Box>
+      <Text as="div" size="1" weight="medium" color="gray" mb="1">
+        {field.label}
+      </Text>
+      <Text
+        size="2"
+        style={{ whiteSpace: field.type === "textarea" ? "pre-wrap" : "normal" }}
+      >
+        {display || "—"}
+      </Text>
+    </Box>
+  );
+};
+
+const renderField = (field, { editing, values, onAttrChange }) =>
+  editing ? (
+    <FieldInput
+      key={field.name}
+      field={field}
+      value={values[field.name]}
+      onChange={onAttrChange}
+    />
+  ) : (
+    <ReadField key={field.name} field={field} value={values[field.name]} />
+  );
+
+// Read-only list of affected parcels (view mode counterpart of ParcelSelectionPanel).
+const AffectedParcels = ({ parcelIds, parcelAddresses = {} }) => (
+  <Card>
+    <Text weight="bold" size="3" className="mb-2 block">
+      Affected parcels ({parcelIds.length})
+    </Text>
+    {parcelIds.length === 0 ? (
+      <Text size="2" color="gray">
+        No parcels recorded for this amendment.
+      </Text>
+    ) : (
+      <Flex direction="column" gap="1" className="max-h-60 overflow-y-auto">
+        {parcelIds.map((id) => (
+          <Flex
+            key={id}
+            justify="between"
+            align="center"
+            gap="2"
+            className="border-b border-gray-100 py-1"
+          >
+            <Flex direction="column" className="min-w-0">
+              <Text size="2" className="truncate">
+                {parcelAddresses[id] || id}
+              </Text>
+              {parcelAddresses[id] && (
+                <Text size="1" color="gray" className="truncate">
+                  {id}
+                </Text>
+              )}
+            </Flex>
+            <a
+              href={parcelMapUrl(id)}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center shrink-0"
+              style={{ color: "var(--accent-11)" }}
+              title="Open parcel on the Base Units map"
+            >
+              <ExternalLinkIcon />
+            </a>
+          </Flex>
+        ))}
+      </Flex>
+    )}
+  </Card>
+);
+
+// Unified amendment view. The same layout renders in read-only ("view") and
+// editable ("edit") modes; only the leaf controls differ.
+const AmendmentView = ({
+  editing,
+  mode,
+  values,
+  onAttrChange,
+  // view-mode map
+  geometry,
+  // edit-mode parcels + map
+  selectedIds,
+  parcelAddresses,
+  dissolved,
+  onToggleParcel,
+  onAddParcel,
+  onRemoveParcel,
+  onClearParcels,
+  // edit-mode actions
+  saving,
+  canSave,
+  status,
+  onSave,
+  onDismissStatus,
+  // shared actions
+  onEdit,
+  onCancel,
+  // provenance
+  editedBy,
+  editedOn,
+}) => {
+  if (!values) {
+    return (
+      <Flex align="center" justify="center" gap="2" className="p-8">
+        <Spinner /> <Text color="gray">Loading…</Text>
+      </Flex>
+    );
+  }
+
+  const topFields = ZONING_FIELDS.filter((f) => TOP_FIELDS.includes(f.name));
+  const ctx = { editing, values, onAttrChange };
+  const parcelIds = parseParcels(values.parcels);
+  const title =
+    values.file_number || (mode === "new" ? "New amendment" : "Amendment");
+
+  return (
+    <Flex direction="column" gap="3">
+      {/* header bar — same shell, different controls */}
+      <Flex justify="between" align="center" gap="2" wrap="wrap">
+        {editing ? (
+          <Button variant="soft" onClick={onCancel}>
+            <ArrowLeftIcon /> {mode === "new" ? "Cancel" : "Back"}
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Text size="5" weight="bold" className="text-[#004445]">
+          {title}
+        </Text>
+        {editing ? (
+          <Button
+            size="3"
+            disabled={!canSave}
+            onClick={onSave}
+            style={canSave ? { backgroundColor: "#004445" } : {}}
+          >
+            {saving ? <Spinner /> : null}
+            {mode === "edit" ? "Save changes" : "Create amendment"}
+          </Button>
+        ) : (
+          <Button onClick={onEdit} style={{ backgroundColor: "#004445" }}>
+            <Pencil1Icon /> Edit
+          </Button>
+        )}
+      </Flex>
+
+      {editing && status && (
+        <Flex
+          align="center"
+          justify="between"
+          gap="2"
+          className="rounded-md px-3 py-2"
+          style={{
+            backgroundColor: status.ok ? "var(--green-3)" : "var(--red-3)",
+            color: status.ok ? "var(--green-11)" : "var(--red-11)",
+          }}
+        >
+          <Flex align="center" gap="2">
+            {status.ok ? <CheckCircledIcon /> : <ExclamationTriangleIcon />}
+            <Text size="2">{status.message}</Text>
+          </Flex>
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={onDismissStatus}
+            aria-label="Dismiss"
+          >
+            <Cross2Icon />
+          </Button>
+        </Flex>
+      )}
+
+      {/* combined block: type + description, then parcels beside the map */}
+      <Card>
+        <Flex direction="column" gap="3">
+          {topFields.map((f) => renderField(f, ctx))}
+          {editing && <ParcelSearch onAddParcel={onAddParcel} />}
+          <Flex direction={{ initial: "column", md: "row" }} gap="3" align="stretch">
+            <Box className="md:w-80 md:shrink-0">
+              {editing ? (
+                <ParcelSelectionPanel
+                  selectedIds={selectedIds}
+                  parcelAddresses={parcelAddresses}
+                  onRemove={onRemoveParcel}
+                  onClear={onClearParcels}
+                />
+              ) : (
+                <AffectedParcels
+                  parcelIds={parcelIds}
+                  parcelAddresses={parcelAddresses}
+                />
+              )}
+            </Box>
+            <Box className="flex-1 min-w-0">
+              {editing ? (
+                <>
+                  <ZoningMap
+                    selectedIds={selectedIds}
+                    onToggleParcel={onToggleParcel}
+                    dissolved={dissolved}
+                    height={MAP_HEIGHT}
+                  />
+                  <Text size="1" color="gray" className="mt-1 block">
+                    Click parcels to add or remove them. The red outline previews
+                    the dissolved amendment boundary that will be saved.
+                  </Text>
+                </>
+              ) : (
+                <AmendmentMiniMap geometry={geometry} height={MAP_HEIGHT} />
+              )}
+            </Box>
+          </Flex>
+        </Flex>
+      </Card>
+
+      {/* details, grouped by workflow stage */}
+      <Card>
+        <Text weight="bold" size="3" className="mb-3 block">
+          Amendment details
+        </Text>
+        <Flex direction="column" gap="4">
+          {FIELD_GROUPS.map((group) => (
+            <Box key={group.title}>
+              <Text
+                size="2"
+                weight="bold"
+                className="mb-2 block"
+                style={{ color: "var(--accent-11)" }}
+              >
+                {group.title}
+              </Text>
+              <Grid columns={{ initial: "1", md: "2" }} gap="3">
+                {group.fields.map((name) =>
+                  renderField(FIELD_BY_NAME[name], ctx)
+                )}
+              </Grid>
+            </Box>
+          ))}
+        </Flex>
+      </Card>
+
+      {(editedBy || editedOn) && (
+        <Text size="1" color="gray">
+          Last edited{editedBy ? ` by ${editedBy}` : ""}
+          {editedOn ? ` on ${editedOn}` : ""}.
+        </Text>
+      )}
+    </Flex>
+  );
+};
+
+export default AmendmentView;

--- a/src/Zoning/Combobox.jsx
+++ b/src/Zoning/Combobox.jsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from "react";
+import { Box, TextField } from "@radix-ui/themes";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+
+// Comma-separated tokens of the current value.
+const tokens = (s) => s.split(",").map((t) => t.trim());
+// The token currently being typed (after the last comma).
+const lastToken = (s) => {
+  const parts = s.split(",");
+  return parts[parts.length - 1].trim();
+};
+// Replace the in-progress last token with a chosen option, keeping prior ones.
+const withReplacedLast = (s, opt) => {
+  const prev = s
+    .split(",")
+    .slice(0, -1)
+    .map((t) => t.trim())
+    .filter(Boolean);
+  return [...prev, opt].join(", ");
+};
+
+// Lightweight combobox: suggests `options` (filtered by the last token) while
+// still allowing free text — supports entering multiple values, e.g. "R1, B4".
+const Combobox = ({
+  value = "",
+  options = [],
+  onChange,
+  placeholder = "Select or type…",
+}) => {
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const ref = useRef(null);
+
+  const token = lastToken(value);
+  const chosen = new Set(
+    tokens(value)
+      .slice(0, -1)
+      .filter(Boolean)
+      .map((t) => t.toUpperCase())
+  );
+  const filtered = options.filter(
+    (o) =>
+      !chosen.has(o.toUpperCase()) &&
+      o.toLowerCase().includes(token.toLowerCase())
+  );
+
+  // keep the highlight in range as the list changes
+  useEffect(() => {
+    setHighlight(0);
+  }, [value, open]);
+
+  // close on outside click
+  useEffect(() => {
+    const onDocMouseDown = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, []);
+
+  const select = (opt) => {
+    onChange(withReplacedLast(value, opt));
+    setOpen(false);
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => Math.min(h + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      if (open && filtered[highlight]) {
+        e.preventDefault();
+        select(filtered[highlight]);
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Box className="relative" ref={ref}>
+      <TextField.Root
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+      >
+        <TextField.Slot side="right">
+          <ChevronDownIcon
+            style={{ cursor: "pointer", color: "var(--gray-9)" }}
+            onClick={() => setOpen((o) => !o)}
+          />
+        </TextField.Slot>
+      </TextField.Root>
+      {open && filtered.length > 0 && (
+        <Box
+          className="absolute left-0 right-0 z-50 mt-1 rounded-md border overflow-y-auto py-1"
+          style={{
+            background: "var(--color-panel-solid)",
+            borderColor: "var(--gray-a6)",
+            boxShadow: "var(--shadow-4)",
+            maxHeight: "200px",
+          }}
+        >
+          {filtered.map((o, i) => (
+            <Box
+              key={o}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => select(o)}
+              onMouseEnter={() => setHighlight(i)}
+              className="px-3 py-1 cursor-pointer"
+              style={{
+                fontSize: "14px",
+                background: i === highlight ? "var(--accent-a3)" : "transparent",
+              }}
+            >
+              {o}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default Combobox;

--- a/src/Zoning/FieldInput.jsx
+++ b/src/Zoning/FieldInput.jsx
@@ -1,0 +1,66 @@
+import { Select, Text, TextArea, TextField } from "@radix-ui/themes";
+import Combobox from "./Combobox";
+
+// sentinel for the "no value" option (Radix Select items can't be empty strings)
+const NONE = "__none__";
+
+// Renders a single amendment field (label + appropriate input).
+// `field` is an entry from ZONING_FIELDS.
+const FieldInput = ({ field, value, onChange }) => {
+  const v = value ?? "";
+
+  let control;
+  if (field.type === "textarea") {
+    control = (
+      <TextArea
+        value={v}
+        onChange={(e) => onChange(field.name, e.target.value)}
+        rows={6}
+      />
+    );
+  } else if (field.type === "select") {
+    control = (
+      <Select.Root
+        value={v || NONE}
+        onValueChange={(val) => onChange(field.name, val === NONE ? "" : val)}
+      >
+        <Select.Trigger className="w-full" placeholder="—" />
+        <Select.Content>
+          <Select.Item value={NONE}>—</Select.Item>
+          {field.options.map((o) => (
+            <Select.Item key={o} value={o}>
+              {o}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+    );
+  } else if (field.type === "combobox") {
+    control = (
+      <Combobox
+        value={v}
+        options={field.options}
+        onChange={(val) => onChange(field.name, val)}
+      />
+    );
+  } else {
+    control = (
+      <TextField.Root
+        type={field.type === "date" ? "date" : "text"}
+        value={v}
+        onChange={(e) => onChange(field.name, e.target.value)}
+      />
+    );
+  }
+
+  return (
+    <label>
+      <Text as="div" size="1" weight="medium" color="gray" mb="1">
+        {field.label}
+      </Text>
+      {control}
+    </label>
+  );
+};
+
+export default FieldInput;

--- a/src/Zoning/ParcelSearch.jsx
+++ b/src/Zoning/ParcelSearch.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { Button, Flex, Text, TextField } from "@radix-ui/themes";
+import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
+import useGeocoder from "../hooks/useGeocoder";
+
+// Matches a Detroit parcel id (so a pasted parcel number is added directly,
+// without geocoding). Mirrors the pattern used in MapGeocoder.
+const PARCEL_REGEX = /^([0,1,2][0-9])([0-9]{6,})([0-9A-Z.-]{1,})$/;
+
+// Search box that geocodes an address (or accepts a parcel id) and adds the
+// matching parcel to the amendment selection.
+const ParcelSearch = ({ onAddParcel }) => {
+  const { feature, error, loading, changeAddress } = useGeocoder();
+  const [value, setValue] = useState("");
+  const [msg, setMsg] = useState(null);
+
+  // when a geocode result arrives, add its parcel
+  useEffect(() => {
+    if (!feature) return;
+    const pid = feature.attributes?.parcel_id;
+    if (pid != null && String(pid).trim() !== "") {
+      onAddParcel(String(pid));
+      setMsg(null);
+      setValue("");
+    } else {
+      setMsg("No parcel found at that location.");
+    }
+  }, [feature]);
+
+  useEffect(() => {
+    if (error) setMsg(typeof error === "string" ? error : "Address not found.");
+  }, [error]);
+
+  const submit = () => {
+    const v = value.trim();
+    if (!v) return;
+    setMsg(null);
+    if (PARCEL_REGEX.test(v)) {
+      onAddParcel(v);
+      setValue("");
+    } else {
+      changeAddress(v);
+    }
+  };
+
+  return (
+    <Flex direction="column" gap="1">
+      <Flex gap="2" align="center">
+        <TextField.Root
+          placeholder="Search an address or parcel ID to add"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          size="2"
+          className="flex-1"
+        >
+          <TextField.Slot>
+            <MagnifyingGlassIcon />
+          </TextField.Slot>
+        </TextField.Root>
+        <Button size="2" variant="soft" onClick={submit} disabled={loading}>
+          {loading ? "…" : "Add"}
+        </Button>
+      </Flex>
+      {msg && (
+        <Text size="1" color="red">
+          {msg}
+        </Text>
+      )}
+    </Flex>
+  );
+};
+
+export default ParcelSearch;

--- a/src/Zoning/ParcelSelectionPanel.jsx
+++ b/src/Zoning/ParcelSelectionPanel.jsx
@@ -1,0 +1,97 @@
+import { Badge, Button, Card, Flex, Text } from "@radix-ui/themes";
+import {
+  Cross2Icon,
+  ExclamationTriangleIcon,
+  ExternalLinkIcon,
+} from "@radix-ui/react-icons";
+import { PARCELS_FIELD_MAX, parcelMapUrl } from "../data/zoning";
+
+// Lists the parcels currently in the amendment grouping.
+const ParcelSelectionPanel = ({
+  selectedIds,
+  parcelAddresses = {},
+  onRemove,
+  onClear,
+}) => {
+  const parcelsString = selectedIds.join("|");
+  const overLimit = parcelsString.length > PARCELS_FIELD_MAX;
+
+  return (
+    <Card>
+      <Flex justify="between" align="center" className="mb-2">
+        <Text weight="bold" size="3">
+          Selected parcels <Badge color="blue">{selectedIds.length}</Badge>
+        </Text>
+        {selectedIds.length > 0 && (
+          <Button size="1" variant="soft" color="red" onClick={onClear}>
+            Clear all
+          </Button>
+        )}
+      </Flex>
+
+      {selectedIds.length === 0 ? (
+        <Text size="2" color="gray">
+          Click parcels on the map to add them to this amendment.
+        </Text>
+      ) : (
+        <>
+          <Flex direction="column" gap="1" className="max-h-48 overflow-y-auto">
+            {selectedIds.map((id) => (
+              <Flex
+                key={id}
+                justify="between"
+                align="center"
+                className="border-b border-gray-100 py-1"
+              >
+                <Flex direction="column" className="min-w-0">
+                  <Text size="2" className="truncate">
+                    {parcelAddresses[id] || id}
+                  </Text>
+                  {parcelAddresses[id] && (
+                    <Text size="1" color="gray" className="truncate">
+                      {id}
+                    </Text>
+                  )}
+                </Flex>
+                <Flex align="center" gap="2" className="shrink-0">
+                  <a
+                    href={parcelMapUrl(id)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center underline"
+                    style={{ color: "var(--accent-11)" }}
+                    title="Open parcel on the Base Units map"
+                  >
+                    <ExternalLinkIcon />
+                  </a>
+                  <Button
+                    size="1"
+                    variant="ghost"
+                    color="red"
+                    onClick={() => onRemove(id)}
+                  >
+                    <Cross2Icon />
+                  </Button>
+                </Flex>
+              </Flex>
+            ))}
+          </Flex>
+
+          <Text
+            size="1"
+            color={overLimit ? "red" : "gray"}
+            className="mt-2 block"
+          >
+            {overLimit && (
+              <ExclamationTriangleIcon className="inline mr-1 text-red-600" />
+            )}
+            {`parcels field: ${parcelsString.length} / ${PARCELS_FIELD_MAX} chars`}
+            {overLimit && " — too long to save, remove some parcels."}
+          </Text>
+        </>
+      )}
+    </Card>
+  );
+};
+
+export default ParcelSelectionPanel;

--- a/src/Zoning/Zoning.jsx
+++ b/src/Zoning/Zoning.jsx
@@ -1,0 +1,522 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  addFeatures,
+  queryFeatures,
+  updateFeatures,
+} from "@esri/arcgis-rest-feature-service";
+import union from "@turf/union";
+import { Card, Flex, Grid, Spinner, Text } from "@radix-ui/themes";
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { Link } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import useGroupAccess from "../hooks/useGroupAccess";
+import {
+  EDITOR_FIELDS,
+  fmtDate,
+  fmtDateTime,
+  geojsonToZoningGeometry,
+  LIST_OUT_FIELDS,
+  PARCEL_ID_FIELD,
+  PARCEL_LAYER_URL,
+  PARCELS_FIELD_MAX,
+  parseParcels,
+  SORT_OPTIONS,
+  sortKey,
+  ZONING_FIELDS,
+  ZONING_GROUP_ID,
+  ZONING_LAYER_URL,
+} from "../data/zoning";
+import AmendmentCardList from "./AmendmentCardList";
+import AmendmentView from "./AmendmentView";
+
+const sqlList = (ids) =>
+  ids.map((id) => `'${String(id).replace(/'/g, "''")}'`).join(",");
+
+const blankAttributes = () =>
+  Object.fromEntries(ZONING_FIELDS.map((f) => [f.name, ""]));
+
+const LIST_PAGE_SIZE = 2000;
+
+const Zoning = () => {
+  const { token } = useAuth();
+  const { hasAccess, checking } = useGroupAccess(ZONING_GROUP_ID);
+
+  // list state
+  const [records, setRecords] = useState([]);
+  const [loadingList, setLoadingList] = useState(false);
+  const [refreshSignal, setRefreshSignal] = useState(0);
+  const [sortField, setSortField] = useState("file_number");
+  const [sortDir, setSortDir] = useState("asc");
+  const [selectedId, setSelectedId] = useState(null); // OBJECTID shown in detail
+
+  // full detail record + geometry for the selected amendment (view mode)
+  const [detailRecord, setDetailRecord] = useState(null);
+  const [detailGeometry, setDetailGeometry] = useState(null);
+  const [detailParcelAddresses, setDetailParcelAddresses] = useState({});
+  const [detailError, setDetailError] = useState(null);
+
+  // edit state
+  const [editing, setEditing] = useState(false);
+  const [mode, setMode] = useState("new"); // "new" | "edit"
+  const [objectId, setObjectId] = useState(null);
+  const [attributes, setAttributes] = useState(blankAttributes);
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [parcelGeoms, setParcelGeoms] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState(null); // { ok, message }
+
+  // load the amendment list
+  useEffect(() => {
+    if (!hasAccess) return;
+    let cancelled = false;
+    setLoadingList(true);
+
+    const loadAllRecords = async () => {
+      const all = [];
+      let resultOffset = 0;
+
+      while (!cancelled) {
+        const res = await queryFeatures({
+          url: ZONING_LAYER_URL,
+          where: "1=1",
+          outFields: LIST_OUT_FIELDS,
+          returnGeometry: false,
+          orderByFields: "OBJECTID",
+          resultOffset,
+          resultRecordCount: LIST_PAGE_SIZE,
+          authentication: token,
+        });
+        const features = res?.features || [];
+        all.push(...features.map((f) => f.attributes));
+
+        if (!res?.exceededTransferLimit || features.length === 0) break;
+        resultOffset += features.length;
+      }
+
+      if (!cancelled) {
+        setRecords(all);
+        setLoadingList(false);
+      }
+    };
+
+    loadAllRecords().catch(() => {
+      if (cancelled) return;
+      setRecords([]);
+      setLoadingList(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasAccess, token, refreshSignal]);
+
+  // load full attributes + geometry for the selected record
+  useEffect(() => {
+    if (!hasAccess || selectedId == null) {
+      setDetailRecord(null);
+      setDetailGeometry(null);
+      setDetailError(null);
+      return;
+    }
+    let cancelled = false;
+    setDetailRecord(null);
+    setDetailGeometry(null);
+    setDetailParcelAddresses({});
+    setDetailError(null);
+    queryFeatures({
+      url: ZONING_LAYER_URL,
+      where: `OBJECTID = ${selectedId}`,
+      outFields: ["*"],
+      returnGeometry: true,
+      f: "geojson",
+      authentication: token,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        const feat = res?.features?.[0] || null;
+        setDetailRecord(feat?.properties || null);
+        setDetailGeometry(feat || null);
+        if (!feat) setDetailError("Could not find that amendment.");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDetailRecord(null);
+        setDetailGeometry(null);
+        setDetailError("Unable to load amendment details.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasAccess, selectedId, token, refreshSignal]);
+
+  // addresses for the viewed record's affected parcels (view mode)
+  useEffect(() => {
+    if (editing || !detailRecord) {
+      setDetailParcelAddresses({});
+      return;
+    }
+    const ids = parseParcels(detailRecord.parcels);
+    if (ids.length === 0) {
+      setDetailParcelAddresses({});
+      return;
+    }
+    let cancelled = false;
+    queryFeatures({
+      url: PARCEL_LAYER_URL,
+      where: `${PARCEL_ID_FIELD} IN (${sqlList(ids)})`,
+      outFields: [PARCEL_ID_FIELD, "address"],
+      returnGeometry: false,
+      authentication: token,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        const map = {};
+        (res?.features || []).forEach((f) => {
+          const pid = f.attributes?.[PARCEL_ID_FIELD];
+          if (pid != null && f.attributes.address) map[pid] = f.attributes.address;
+        });
+        setDetailParcelAddresses(map);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDetailParcelAddresses({});
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [editing, detailRecord, token]);
+
+  const sortedRecords = useMemo(() => {
+    const opt = SORT_OPTIONS.find((o) => o.value === sortField);
+    const kind = opt?.kind || "string";
+    return [...records].sort((a, b) => {
+      const av = sortKey(a[sortField], kind);
+      const bv = sortKey(b[sortField], kind);
+      if (av < bv) return sortDir === "asc" ? -1 : 1;
+      if (av > bv) return sortDir === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [records, sortField, sortDir]);
+
+  // dissolved boundary for the edit-mode preview (WGS84)
+  const dissolved = useMemo(() => {
+    const feats = selectedIds.map((id) => parcelGeoms[id]).filter(Boolean);
+    if (feats.length === 0) return null;
+    if (feats.length === 1) return feats[0];
+    try {
+      return union({ type: "FeatureCollection", features: feats });
+    } catch (e) {
+      return null;
+    }
+  }, [selectedIds, parcelGeoms]);
+
+  // parcel_id -> address, from the fetched parcel features
+  const parcelAddresses = useMemo(() => {
+    const map = {};
+    Object.entries(parcelGeoms).forEach(([id, feat]) => {
+      const addr = feat?.properties?.address;
+      if (addr) map[id] = addr;
+    });
+    return map;
+  }, [parcelGeoms]);
+
+  const fetchParcelGeom = (parcelId) =>
+    queryFeatures({
+      url: PARCEL_LAYER_URL,
+      where: `${PARCEL_ID_FIELD} = '${String(parcelId).replace(/'/g, "''")}'`,
+      outFields: [PARCEL_ID_FIELD, "address"],
+      returnGeometry: true,
+      f: "geojson",
+      authentication: token,
+    }).then((res) => res?.features?.[0] || null);
+
+  const addParcelId = (parcelId) => {
+    setSelectedIds((ids) => (ids.includes(parcelId) ? ids : [...ids, parcelId]));
+    fetchParcelGeom(parcelId)
+      .then((feature) => {
+        if (feature) {
+          setParcelGeoms((g) => ({ ...g, [parcelId]: feature }));
+          return;
+        }
+        setSelectedIds((ids) => ids.filter((id) => id !== parcelId));
+        setParcelGeoms((g) => {
+          const next = { ...g };
+          delete next[parcelId];
+          return next;
+        });
+        setStatus({ ok: false, message: `Parcel ${parcelId} was not found.` });
+      })
+      .catch(() => {
+        setSelectedIds((ids) => ids.filter((id) => id !== parcelId));
+        setParcelGeoms((g) => {
+          const next = { ...g };
+          delete next[parcelId];
+          return next;
+        });
+        setStatus({ ok: false, message: `Unable to load parcel ${parcelId}.` });
+      });
+  };
+
+  const handleToggleParcel = (parcelId) => {
+    setStatus(null);
+    if (selectedIds.includes(parcelId)) {
+      setSelectedIds((ids) => ids.filter((id) => id !== parcelId));
+      return;
+    }
+    addParcelId(parcelId);
+  };
+
+  const handleAddParcel = (parcelId) => {
+    setStatus(null);
+    if (selectedIds.includes(parcelId)) return;
+    addParcelId(parcelId);
+  };
+
+  const handleRemoveParcel = (parcelId) =>
+    setSelectedIds((ids) => ids.filter((id) => id !== parcelId));
+
+  const handleClearParcels = () => {
+    setSelectedIds([]);
+    setParcelGeoms({});
+  };
+
+  const handleAttrChange = (name, value) =>
+    setAttributes((a) => ({ ...a, [name]: value }));
+
+  // auto-dismiss success messages
+  useEffect(() => {
+    if (status?.ok) {
+      const t = setTimeout(() => setStatus(null), 4000);
+      return () => clearTimeout(t);
+    }
+  }, [status]);
+
+  // ---- navigation ----
+  const handleSelectCard = (rec) => {
+    setSelectedId(rec.OBJECTID);
+    setEditing(false);
+    setStatus(null);
+  };
+
+  const handleNew = () => {
+    setMode("new");
+    setObjectId(null);
+    setSelectedId(null);
+    setAttributes(blankAttributes());
+    setSelectedIds([]);
+    setParcelGeoms({});
+    setStatus(null);
+    setEditing(true);
+  };
+
+  const handleEdit = () => {
+    if (selectedId == null || !detailRecord || detailRecord.OBJECTID !== selectedId) {
+      return;
+    }
+    setStatus(null);
+    setMode("edit");
+    setObjectId(selectedId);
+    setEditing(true);
+
+    // seed the form from the full detail record
+    const attrs = detailRecord || {};
+    const next = blankAttributes();
+    ZONING_FIELDS.forEach((f) => {
+      const raw = attrs[f.name];
+      next[f.name] = f.type === "date" ? fmtDate(raw) : raw ?? "";
+    });
+    setAttributes(next);
+
+    // rehydrate parcels from the `parcels` string
+    const ids = (attrs.parcels || "")
+      .split("|")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setSelectedIds(ids);
+    setParcelGeoms({});
+    if (ids.length > 0) {
+      queryFeatures({
+        url: PARCEL_LAYER_URL,
+        where: `${PARCEL_ID_FIELD} IN (${sqlList(ids)})`,
+        outFields: [PARCEL_ID_FIELD, "address"],
+        returnGeometry: true,
+        f: "geojson",
+        authentication: token,
+      })
+        .then((res) => {
+          const map = {};
+          (res?.features || []).forEach((feat) => {
+            const pid = feat.properties?.[PARCEL_ID_FIELD];
+            if (pid != null) map[pid] = feat;
+          });
+          setParcelGeoms(map);
+        })
+        .catch(() => {
+          setParcelGeoms({});
+          setStatus({
+            ok: false,
+            message: "Unable to load parcel geometry for this amendment.",
+          });
+        });
+    }
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setStatus(null);
+  };
+
+  const parcelsString = selectedIds.join("|");
+  const overLimit = parcelsString.length > PARCELS_FIELD_MAX;
+  const canSave = selectedIds.length > 0 && !!dissolved && !overLimit && !saving;
+
+  const handleSave = () => {
+    if (!canSave) return;
+    setSaving(true);
+    setStatus(null);
+
+    const outAttrs = {};
+    ZONING_FIELDS.forEach((f) => {
+      const v = attributes[f.name];
+      outAttrs[f.name] = v === "" || v == null ? null : v;
+    });
+    outAttrs.parcels = parcelsString;
+
+    const geometry = geojsonToZoningGeometry(dissolved.geometry);
+    const feature =
+      mode === "edit"
+        ? { attributes: { OBJECTID: objectId, ...outAttrs }, geometry }
+        : { attributes: outAttrs, geometry };
+    const op = mode === "edit" ? updateFeatures : addFeatures;
+
+    op({ url: ZONING_LAYER_URL, features: [feature], authentication: token })
+      .then((res) => {
+        const result = (res?.addResults || res?.updateResults || [])[0];
+        if (result?.success) {
+          const newId = result.objectId ?? objectId;
+          const wasNew = mode === "new";
+          setObjectId(newId);
+          setSelectedId(newId);
+          setMode("edit");
+          setStatus({
+            ok: true,
+            message: wasNew ? "Amendment created." : "Changes saved.",
+          });
+          setRefreshSignal((n) => n + 1);
+        } else {
+          setStatus({
+            ok: false,
+            message: result?.error?.description || "Save failed.",
+          });
+        }
+        setSaving(false);
+      })
+      .catch((err) => {
+        setStatus({ ok: false, message: err?.message || "Save failed." });
+        setSaving(false);
+      });
+  };
+
+  // ---- access gating ----
+  if (checking) {
+    return (
+      <Flex align="center" justify="center" gap="2" className="p-8">
+        <Spinner /> <Text>Checking access…</Text>
+      </Flex>
+    );
+  }
+
+  if (!hasAccess) {
+    return (
+      <Flex direction="column" align="center" justify="center" className="p-8" gap="2">
+        <Card className="bg-red-100 border-red-300 max-w-md">
+          <Flex align="center" gap="2" className="mb-1">
+            <ExclamationTriangleIcon className="text-red-600" />
+            <Text weight="medium" className="text-red-700">
+              No access
+            </Text>
+          </Flex>
+          <Text size="2" className="text-red-600">
+            This tool is restricted to City Planning Commission staff. Please{" "}
+            <Link to="/login?app=zoning" className="underline">
+              sign in
+            </Link>{" "}
+            with an account in the CPC zoning group.
+          </Text>
+        </Card>
+      </Flex>
+    );
+  }
+
+  // values + provenance for the unified view
+  const viewValues = editing ? attributes : detailRecord;
+  const editedBy = !editing ? detailRecord?.[EDITOR_FIELDS.editor] : null;
+  const editedOn = !editing ? fmtDateTime(detailRecord?.[EDITOR_FIELDS.edited]) : null;
+
+  return (
+    <Grid
+      columns={{ initial: "1fr", sm: "1fr 2fr" }}
+      gap={{ initial: "2", sm: "4" }}
+      p={{ initial: "2", sm: "2", lg: "4" }}
+    >
+      <AmendmentCardList
+        records={sortedRecords}
+        loading={loadingList}
+        selectedId={selectedId}
+        sortField={sortField}
+        sortDir={sortDir}
+        onSortField={setSortField}
+        onToggleDir={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+        onSelect={handleSelectCard}
+        onNew={handleNew}
+      />
+
+      <Flex direction="column" className="min-w-0">
+        {editing || selectedId != null ? (
+          detailError && !editing ? (
+            <Card className="bg-red-100 border-red-300">
+              <Flex align="center" gap="2">
+                <ExclamationTriangleIcon className="text-red-600" />
+                <Text size="2" className="text-red-700">
+                  {detailError}
+                </Text>
+              </Flex>
+            </Card>
+          ) : (
+            <AmendmentView
+              editing={editing}
+              mode={mode}
+              values={viewValues}
+              onAttrChange={handleAttrChange}
+              geometry={detailGeometry}
+              selectedIds={selectedIds}
+              parcelAddresses={editing ? parcelAddresses : detailParcelAddresses}
+              dissolved={dissolved}
+              onToggleParcel={handleToggleParcel}
+              onAddParcel={handleAddParcel}
+              onRemoveParcel={handleRemoveParcel}
+              onClearParcels={handleClearParcels}
+              saving={saving}
+              canSave={canSave}
+              status={status}
+              onSave={handleSave}
+              onDismissStatus={() => setStatus(null)}
+              onEdit={handleEdit}
+              onCancel={handleCancel}
+              editedBy={editedBy}
+              editedOn={editedOn}
+            />
+          )
+        ) : (
+          <Flex align="center" justify="center" className="h-full p-8">
+            <Text size="3" color="gray">
+              Select an amendment from the list, or create a new one.
+            </Text>
+          </Flex>
+        )}
+      </Flex>
+    </Grid>
+  );
+};
+
+export default Zoning;

--- a/src/Zoning/ZoningMap.jsx
+++ b/src/Zoning/ZoningMap.jsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import maplibregl from "maplibre-gl";
+import bbox from "@turf/bbox";
+import { baseStyle } from "../styles/mapstyle.js";
+
+// Map for selecting parcels into a zoning-amendment grouping.
+// - click a parcel to toggle it in/out of the selection (fine control)
+// - selected parcels are highlighted via a vector-tile filter on `parcel_id`
+// - the dissolved amendment boundary is previewed as an outline
+const SELECTION_COLOR = "#2563eb";
+
+const ZoningMap = ({ selectedIds, onToggleParcel, dissolved, height = "65vh" }) => {
+  const [theMap, setTheMap] = useState(null);
+  // keep the latest toggle callback so the click handler isn't stale
+  const toggleRef = useRef(onToggleParcel);
+  useEffect(() => {
+    toggleRef.current = onToggleParcel;
+  }, [onToggleParcel]);
+
+  useEffect(() => {
+    const detroitBbox = [-83.287803, 42.255192, -82.910451, 42.45023];
+
+    const map = new maplibregl.Map({
+      container: "zoning-map",
+      style: baseStyle,
+      bounds: detroitBbox,
+    });
+
+    map.addControl(new maplibregl.NavigationControl(), "top-left");
+
+    map.on("load", () => {
+      map.resize();
+
+      // make parcel outlines faintly visible so the user can aim clicks
+      map.setPaintProperty("parcel-line", "line-opacity", {
+        base: 1,
+        stops: [
+          [14, 0],
+          [14.1, 0.2],
+        ],
+      });
+
+      // highlight fill for selected parcels (filtered by parcel_id)
+      map.addLayer({
+        id: "zoning-selection-fill",
+        type: "fill",
+        source: "bu_parcels",
+        "source-layer": "Parcels (Current)",
+        filter: ["in", "parcel_id", ""],
+        paint: {
+          "fill-color": SELECTION_COLOR,
+          "fill-opacity": 0.35,
+        },
+      });
+      map.addLayer({
+        id: "zoning-selection-line",
+        type: "line",
+        source: "bu_parcels",
+        "source-layer": "Parcels (Current)",
+        filter: ["in", "parcel_id", ""],
+        paint: {
+          "line-color": SELECTION_COLOR,
+          "line-width": 1.5,
+        },
+      });
+
+      // dissolved amendment-boundary preview
+      map.addSource("zoning-dissolved", {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+      map.addLayer({
+        id: "zoning-dissolved-line",
+        type: "line",
+        source: "zoning-dissolved",
+        paint: {
+          "line-color": "#b91c1c",
+          "line-width": 2.5,
+        },
+      });
+
+      setTheMap(map);
+    });
+
+    map.on("click", (e) => {
+      const features = map.queryRenderedFeatures(e.point, {
+        layers: ["parcel-fill"],
+      });
+      if (features.length > 0) {
+        const parcelId = features[0].properties?.parcel_id;
+        if (parcelId) toggleRef.current(parcelId);
+      }
+    });
+
+    // pointer cursor over parcels
+    map.on("mouseenter", "parcel-fill", () => {
+      map.getCanvas().style.cursor = "pointer";
+    });
+    map.on("mouseleave", "parcel-fill", () => {
+      map.getCanvas().style.cursor = "";
+    });
+
+    return () => map.remove();
+  }, []);
+
+  // update the highlight filter when the selection changes
+  useEffect(() => {
+    if (!theMap) return;
+    const filter = ["in", "parcel_id", ...(selectedIds.length ? selectedIds : [""])];
+    theMap.setFilter("zoning-selection-fill", filter);
+    theMap.setFilter("zoning-selection-line", filter);
+  }, [theMap, selectedIds]);
+
+  // update the dissolved preview; fit to it once (no animation), not on every change
+  const didFitRef = useRef(false);
+  useEffect(() => {
+    if (!theMap) return;
+    const src = theMap.getSource("zoning-dissolved");
+    if (!src) return;
+    if (dissolved) {
+      src.setData(dissolved);
+      if (!didFitRef.current) {
+        try {
+          theMap.fitBounds(bbox(dissolved), {
+            padding: 60,
+            maxZoom: 18,
+            animate: false,
+          });
+          didFitRef.current = true;
+        } catch (e) {
+          /* ignore degenerate bounds */
+        }
+      }
+    } else {
+      src.setData({ type: "FeatureCollection", features: [] });
+    }
+  }, [theMap, dissolved]);
+
+  return <div id="zoning-map" style={{ height, minHeight: "300px" }} />;
+};
+
+export default ZoningMap;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -9,8 +9,30 @@ export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [username, setUsername] = useState("");
   const [token, setToken] = useState(null);
+  const [groups, setGroups] = useState([]);
+  const [groupsLoading, setGroupsLoading] = useState(false);
 
   const portalUrl = "https://detroitmi.maps.arcgis.com";
+
+  // fetch the signed-in user's group memberships
+  const fetchGroups = (userId, userToken) => {
+    setGroupsLoading(true);
+    const url = `${portalUrl}/sharing/rest/community/users/${encodeURIComponent(
+      userId
+    )}?f=json&token=${userToken}`;
+    return fetch(url)
+      .then((r) => r.json())
+      .then((data) => {
+        setGroups(Array.isArray(data?.groups) ? data.groups : []);
+        setGroupsLoading(false);
+      })
+      .catch(() => {
+        setGroups([]);
+        setGroupsLoading(false);
+      });
+  };
+
+  const isInGroup = (groupId) => groups.some((g) => g.id === groupId);
 
   useEffect(() => {
     const info = new OAuthInfo({
@@ -29,18 +51,24 @@ export const AuthProvider = ({ children }) => {
       })
       .catch(() => {
         setIsAuthenticated(false);
+        setGroups([]);
+        setGroupsLoading(false);
       });
   }, []);
 
   const getCurrentUser = () => {
+    setGroupsLoading(true);
     esriId
       .getCredential(portalUrl + "/sharing")
       .then((credentials) => {
         setUsername(credentials.userId);
         setToken(credentials.token);
+        return fetchGroups(credentials.userId, credentials.token);
       })
       .catch((error) => {
         console.error(error);
+        setGroups([]);
+        setGroupsLoading(false);
       });
   };
 
@@ -65,11 +93,22 @@ export const AuthProvider = ({ children }) => {
     setIsAuthenticated(false);
     setUsername("");
     setToken(null);
+    setGroups([]);
+    setGroupsLoading(false);
   };
 
   return (
     <AuthContext.Provider
-      value={{ isAuthenticated, token, username, handleSignIn, handleSignOut }}
+      value={{
+        isAuthenticated,
+        token,
+        username,
+        groups,
+        groupsLoading,
+        isInGroup,
+        handleSignIn,
+        handleSignOut,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/data/apps.js
+++ b/src/data/apps.js
@@ -1,4 +1,5 @@
 import { Crosshair2Icon, EnvelopeOpenIcon, GlobeIcon, HomeIcon } from "@radix-ui/react-icons";
+import { ZONING_GROUP_ID } from "./groups";
 
 export const apps = {
     '/': {
@@ -42,6 +43,18 @@ export const apps = {
         ],
         icon: "EnvelopeOpenIcon",
         private: true,
+        show: true
+    },
+    'zoning': {
+        name: 'Zoning Amendments',
+        url: `/zoning`,
+        description: `Create and edit zoning amendment applications.`,
+        questions: [
+            `I need to update the parcels and status for a zoning amendment.`
+        ],
+        icon: "GroupIcon",
+        private: true,
+        group: ZONING_GROUP_ID,
         show: true
     }
 }

--- a/src/data/groups.js
+++ b/src/data/groups.js
@@ -1,0 +1,7 @@
+// ArcGIS Online group IDs used for access control.
+// Kept dependency-free so it can be imported anywhere (incl. eagerly-loaded
+// modules like apps.js) without pulling in heavier code.
+
+// City Planning Commission zoning staff.
+// https://detroitmi.maps.arcgis.com/home/group.html?id=9696b363ff44463e8e816611c6022124
+export const ZONING_GROUP_ID = "9696b363ff44463e8e816611c6022124";

--- a/src/data/zoning.js
+++ b/src/data/zoning.js
@@ -1,0 +1,254 @@
+// Configuration for the Zoning Amendment editor app.
+// Front-end editor for the cpc_zoning_application feature layer.
+
+import { geojsonToArcGIS } from "@terraformer/arcgis";
+import { ZONING_GROUP_ID } from "./groups";
+
+export { ZONING_GROUP_ID };
+
+// The feature layer we read from / write to.
+export const ZONING_LAYER_URL =
+  "https://services2.arcgis.com/qvkbeam7Wirps6zC/arcgis/rest/services/cpc_zoning_application/FeatureServer/0";
+
+// The layer stores geometry in Web Mercator (102100 / 3857).
+export const ZONING_LAYER_WKID = 102100;
+
+// ArcGIS Online group that gates access to this tool — see ./groups (re-exported above).
+
+export const PORTAL_URL = "https://detroitmi.maps.arcgis.com";
+
+// The parcel layer we pull authoritative parcel geometry from.
+// (matches layers.parcel in src/data/layers.js)
+export const PARCEL_LAYER_URL =
+  "https://services2.arcgis.com/qvkbeam7Wirps6zC/arcgis/rest/services/parcel_file_current/FeatureServer/0";
+export const PARCEL_ID_FIELD = "parcel_id";
+
+// Max length of the `parcels` string field on the layer.
+export const PARCELS_FIELD_MAX = 3000;
+
+// Detroit zoning classifications, offered as suggestions on the zoning fields.
+export const ZONING_OPTIONS = [
+  "R1", "R2", "R3", "R4", "R5", "R6",
+  "B1", "B2", "B3", "B4", "B5", "B6",
+  "M1", "M2", "M3", "M4", "M5",
+  "SD1", "SD2", "SD4", "SD5",
+  "P1", "PC", "PCA", "PD", "PR",
+  "MKT", "TM", "W1",
+];
+
+// Editable attribute fields, in display order, with input types.
+// type: "text" | "textarea" | "date" | "select" | "combobox"
+export const ZONING_FIELDS = [
+  { name: "file_number", label: "File number", type: "text" },
+  { name: "petition_number", label: "Petition number", type: "text" },
+  {
+    name: "application_type",
+    label: "Application type",
+    type: "select",
+    options: ["Rezoning", "PD / PC / PCA Zoning Change", "Map Amendment"],
+  },
+  { name: "application_description", label: "Description", type: "textarea" },
+  { name: "received_date", label: "Received date", type: "date" },
+  { name: "check_number", label: "Check number", type: "text" },
+  { name: "assigned_to", label: "Assigned to", type: "text" },
+  {
+    name: "current_zoning",
+    label: "Current zoning",
+    type: "combobox",
+    options: ZONING_OPTIONS,
+  },
+  {
+    name: "proposed_zoning",
+    label: "Proposed zoning",
+    type: "combobox",
+    options: ZONING_OPTIONS,
+  },
+  {
+    name: "cpc_staff_proposed_zoning",
+    label: "CPC staff proposed zoning",
+    type: "combobox",
+    options: ZONING_OPTIONS,
+  },
+  {
+    name: "cpc_staff_recommendation",
+    label: "CPC staff recommendation",
+    type: "select",
+    options: ["Approve", "Deny"],
+  },
+  { name: "cpc_staff_report_date", label: "CPC staff report date", type: "date" },
+  { name: "cpc_public_hearing_date", label: "CPC public hearing date", type: "date" },
+  { name: "cpc_action_date", label: "CPC action date", type: "date" },
+  { name: "cpc_action", label: "CPC action", type: "text" },
+  { name: "cpc_refer_to_council_date", label: "CPC refer to council date", type: "date" },
+  { name: "council_hearing_1_date", label: "Council hearing 1 date", type: "date" },
+  { name: "ped_public_hearing_date", label: "PED public hearing date", type: "date" },
+  {
+    name: "ped_recommendation",
+    label: "PED recommendation",
+    type: "select",
+    options: ["Approve", "Deny"],
+  },
+  { name: "council_action_date", label: "Council action date", type: "date" },
+  { name: "council_action", label: "Council action", type: "text" },
+];
+
+export const ZONING_DATE_FIELDS = ZONING_FIELDS.filter((f) => f.type === "date").map(
+  (f) => f.name
+);
+
+export const FIELD_BY_NAME = Object.fromEntries(
+  ZONING_FIELDS.map((f) => [f.name, f])
+);
+
+// Detail fields grouped by workflow stage (application_type & description are
+// shown in the map block, so they're omitted here).
+export const FIELD_GROUPS = [
+  {
+    title: "Intake",
+    fields: [
+      "file_number",
+      "petition_number",
+      "received_date",
+      "check_number",
+      "assigned_to",
+    ],
+  },
+  {
+    title: "Zoning",
+    fields: ["current_zoning", "proposed_zoning", "cpc_staff_proposed_zoning"],
+  },
+  {
+    title: "CPC review",
+    fields: [
+      "cpc_staff_recommendation",
+      "cpc_staff_report_date",
+      "cpc_public_hearing_date",
+      "cpc_action_date",
+      "cpc_action",
+      "cpc_refer_to_council_date",
+    ],
+  },
+  {
+    title: "Planning & Development (PED)",
+    fields: ["ped_public_hearing_date", "ped_recommendation"],
+  },
+  {
+    title: "City Council",
+    fields: ["council_hearing_1_date", "council_action_date", "council_action"],
+  },
+];
+
+// Editor-tracking fields (system-maintained, not editable). Used for the
+// card list's "last edited" sort and the read-only provenance line.
+export const EDITOR_FIELDS = {
+  creator: "Creator",
+  created: "CreationDate",
+  editor: "Editor",
+  edited: "EditDate",
+};
+
+// Fields fetched for the left-hand card list.
+export const LIST_OUT_FIELDS = [
+  "OBJECTID",
+  "file_number",
+  "application_type",
+  "application_description",
+  "current_zoning",
+  "proposed_zoning",
+  "assigned_to",
+  "received_date",
+  "cpc_public_hearing_date",
+  "cpc_action",
+  "council_action",
+  "parcels",
+  EDITOR_FIELDS.creator,
+  EDITOR_FIELDS.created,
+  EDITOR_FIELDS.editor,
+  EDITOR_FIELDS.edited,
+];
+
+// Sort options offered above the card list.
+export const SORT_OPTIONS = [
+  { value: "file_number", label: "File number", kind: "string" },
+  { value: "received_date", label: "Date received", kind: "date" },
+  { value: EDITOR_FIELDS.edited, label: "Last edited", kind: "date" },
+  { value: "assigned_to", label: "Assigned to", kind: "string" },
+];
+
+// Parse a pipe-delimited `parcels` value into an array of ids.
+export const parseParcels = (parcels) =>
+  parcels ? parcels.split("|").map((s) => s.trim()).filter(Boolean) : [];
+
+// Number of parcels in a pipe-delimited `parcels` value.
+export const countParcels = (parcels) => parseParcels(parcels).length;
+
+// Link to a parcel on the Base Units map (opens in a new tab).
+export const parcelMapUrl = (parcelId) =>
+  `/map?layer=parcel&id=${encodeURIComponent(parcelId)}`;
+
+// DateOnly value (epoch-ms or ISO string) -> "YYYY-MM-DD".
+export const fmtDate = (v) => {
+  if (v == null || v === "") return "";
+  if (typeof v === "number") return new Date(v).toISOString().slice(0, 10);
+  return String(v).slice(0, 10);
+};
+
+// Datetime value (epoch-ms) -> locale string, for EditDate/CreationDate.
+export const fmtDateTime = (v) => {
+  if (v == null || v === "") return "";
+  const ms = typeof v === "number" ? v : Date.parse(v);
+  if (Number.isNaN(ms)) return "";
+  return new Date(ms).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+// Comparable sort key for a record value.
+export const sortKey = (value, kind) => {
+  if (value == null || value === "") return kind === "date" ? 0 : "";
+  if (kind === "date") {
+    return typeof value === "number" ? value : Date.parse(value) || 0;
+  }
+  return String(value).toLowerCase();
+};
+
+// Derive a human "status" from the furthest-along workflow field.
+export const deriveStatus = (a) => {
+  if (a.council_action) return `Council: ${a.council_action}`;
+  if (a.cpc_action) return `CPC: ${a.cpc_action}`;
+  if (a.cpc_public_hearing_date)
+    return `CPC hearing ${fmtDate(a.cpc_public_hearing_date)}`;
+  if (a.received_date) return `Received ${fmtDate(a.received_date)}`;
+  return "Draft";
+};
+
+// ---- geometry helpers ----
+
+// Project a single [lng, lat] (EPSG:4326) coordinate to Web Mercator meters
+// (EPSG:3857 / 102100). Spherical mercator — exact, no dependency needed.
+const R = 6378137;
+const lngLatToWebMercator = ([lng, lat]) => {
+  const x = (R * lng * Math.PI) / 180;
+  const y = R * Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 360));
+  return [x, y];
+};
+
+// Recursively project a GeoJSON coordinate array (any nesting depth).
+const projectCoords = (coords) =>
+  typeof coords[0] === "number"
+    ? lngLatToWebMercator(coords)
+    : coords.map(projectCoords);
+
+// Convert a dissolved GeoJSON geometry (WGS84) into an Esri polygon geometry
+// in the layer's spatial reference (102100), ready for applyEdits.
+export const geojsonToZoningGeometry = (geojsonGeometry) => {
+  const projected = {
+    type: geojsonGeometry.type,
+    coordinates: projectCoords(geojsonGeometry.coordinates),
+  };
+  const esri = geojsonToArcGIS(projected);
+  esri.spatialReference = { wkid: ZONING_LAYER_WKID };
+  return esri;
+};

--- a/src/hooks/useGroupAccess.js
+++ b/src/hooks/useGroupAccess.js
@@ -1,0 +1,16 @@
+import { useAuth } from "../contexts/AuthContext";
+
+// Whether the signed-in ArcGIS user belongs to a given group.
+// Reads from AuthContext (groups are fetched once on sign-in).
+// Returns { hasAccess, checking }.
+// Note: this gates the UI only — the real guard is the feature service's
+// editing permission, which ArcGIS enforces server-side on save.
+const useGroupAccess = (groupId) => {
+  const { isAuthenticated, groupsLoading, isInGroup } = useAuth();
+  return {
+    hasAccess: isAuthenticated && isInGroup(groupId),
+    checking: isAuthenticated && groupsLoading,
+  };
+};
+
+export default useGroupAccess;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -52,3 +52,20 @@ a {
 p {
   @apply py-2;
 }
+
+/* subtle hover tooltip for the zoning amendment minimap */
+.zoning-parcel-tip {
+  opacity: 0.8;
+}
+.zoning-parcel-tip .maplibregl-popup-content {
+  background: rgba(17, 24, 39, 0.75);
+  color: #fff;
+  padding: 2px 6px;
+  font-size: 11px;
+  border-radius: 3px;
+  box-shadow: none;
+  pointer-events: none;
+}
+.zoning-parcel-tip .maplibregl-popup-tip {
+  display: none;
+}


### PR DESCRIPTION
## Summary

A new **Zoning Amendments** tool for City Planning Commission staff to manage zoning amendment applications, backed by the `cpc_zoning_application` ArcGIS feature layer. Visibility and access are restricted to the DSA-CPC ArcGIS Online group.

## Key files

- New: `src/Zoning/*` (app + components), `src/data/zoning.js`, `src/data/groups.js`, `src/hooks/useGroupAccess.js`
- Changed: `src/App.jsx` (route), `src/data/apps.js` (registry), `src/contexts/AuthContext.jsx` (groups), `src/Homepage.jsx` (sections + filter), `src/styles/index.css`
- Added dependency: `@turf/union`