### PR TITLE
Zoning amendments: districts overlay, per-parcel zoning, auto file numbers & field updates

### DIFF
--- a/src/Zoning/AmendmentMiniMap.jsx
+++ b/src/Zoning/AmendmentMiniMap.jsx
@@ -2,9 +2,14 @@ import { useEffect, useRef, useState } from "react";
 import maplibregl from "maplibre-gl";
 import bbox from "@turf/bbox";
 import { baseStyle } from "../styles/mapstyle.js";
+import {
+  addZoningDistrictsLayers,
+  setZoningDistrictsVisible,
+} from "./zoningOverlay";
 
-// Small read-only map that displays a single amendment's saved geometry.
-const AmendmentMiniMap = ({ geometry, height = "300px" }) => {
+// Small read-only map that displays a single amendment's saved geometry, with
+// an optional zoning-districts overlay (`showZoning`) for context.
+const AmendmentMiniMap = ({ geometry, showZoning = false, height = "300px" }) => {
   const containerRef = useRef(null);
   const [theMap, setTheMap] = useState(null);
 
@@ -28,6 +33,10 @@ const AmendmentMiniMap = ({ geometry, height = "300px" }) => {
       map.touchZoomRotate.disable();
       map.keyboard.disable();
 
+      // zoning-districts overlay (hidden until toggled on) — added before the
+      // amendment polygon so the saved boundary stays on top of it
+      addZoningDistrictsLayers(map);
+
       map.addSource("amendment", {
         type: "geojson",
         data: { type: "FeatureCollection", features: [] },
@@ -45,7 +54,7 @@ const AmendmentMiniMap = ({ geometry, height = "300px" }) => {
         paint: { "line-color": "#1d4ed8", "line-width": 2 },
       });
 
-      // hover tooltip showing the underlying parcel id
+      // hover tooltip showing the underlying parcel id + its zoning
       const popup = new maplibregl.Popup({
         closeButton: false,
         closeOnClick: false,
@@ -53,13 +62,19 @@ const AmendmentMiniMap = ({ geometry, height = "300px" }) => {
         className: "zoning-parcel-tip",
       });
       map.on("mousemove", "parcel-fill", (e) => {
-        const pid = e.features?.[0]?.properties?.parcel_id;
+        const props = e.features?.[0]?.properties;
+        const pid = props?.parcel_id;
         if (!pid) {
           popup.remove();
           return;
         }
         map.getCanvas().style.cursor = "crosshair";
-        popup.setLngLat(e.lngLat).setText(String(pid)).addTo(map);
+        // parcel id · address · zoning all ride on the parcel vector tiles,
+        // so this works for every parcel — not just the amendment's own
+        const text = [pid, props.address, props.zoning_district]
+          .filter(Boolean)
+          .join(" · ");
+        popup.setLngLat(e.lngLat).setText(text).addTo(map);
       });
       map.on("mouseleave", "parcel-fill", () => {
         map.getCanvas().style.cursor = "";
@@ -71,6 +86,25 @@ const AmendmentMiniMap = ({ geometry, height = "300px" }) => {
 
     return () => map.remove();
   }, []);
+
+  // show/hide the zoning-districts overlay; when on, fade the amendment fill to
+  // a faint gray so the district color shows through (outline still marks it)
+  useEffect(() => {
+    if (!theMap) return;
+    setZoningDistrictsVisible(theMap, showZoning);
+    if (theMap.getLayer("amendment-fill")) {
+      theMap.setPaintProperty(
+        "amendment-fill",
+        "fill-color",
+        showZoning ? "#6b7280" : "#2563eb"
+      );
+      theMap.setPaintProperty(
+        "amendment-fill",
+        "fill-opacity",
+        showZoning ? 0.1 : 0.3
+      );
+    }
+  }, [theMap, showZoning]);
 
   useEffect(() => {
     if (!theMap) return;

--- a/src/Zoning/AmendmentView.jsx
+++ b/src/Zoning/AmendmentView.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Box,
   Button,
@@ -5,6 +6,7 @@ import {
   Flex,
   Grid,
   Spinner,
+  Switch,
   Text,
 } from "@radix-ui/themes";
 import {
@@ -18,6 +20,7 @@ import {
 import {
   FIELD_BY_NAME,
   FIELD_GROUPS,
+  REQUIRED_FIELDS,
   ZONING_FIELDS,
   fmtDate,
   parcelMapUrl,
@@ -26,6 +29,7 @@ import {
 import FieldInput from "./FieldInput";
 import ParcelSearch from "./ParcelSearch";
 import ParcelSelectionPanel from "./ParcelSelectionPanel";
+import ZoningBadge from "./ZoningBadge";
 import ZoningMap from "./ZoningMap";
 import AmendmentMiniMap from "./AmendmentMiniMap";
 
@@ -65,7 +69,7 @@ const renderField = (field, { editing, values, onAttrChange }) =>
   );
 
 // Read-only list of affected parcels (view mode counterpart of ParcelSelectionPanel).
-const AffectedParcels = ({ parcelIds, parcelAddresses = {} }) => (
+const AffectedParcels = ({ parcelIds, parcelAddresses = {}, parcelZoning = {} }) => (
   <Card>
     <Text weight="bold" size="3" className="mb-2 block">
       Affected parcels ({parcelIds.length})
@@ -94,16 +98,19 @@ const AffectedParcels = ({ parcelIds, parcelAddresses = {} }) => (
                 </Text>
               )}
             </Flex>
-            <a
-              href={parcelMapUrl(id)}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center shrink-0"
-              style={{ color: "var(--accent-11)" }}
-              title="Open parcel on the Base Units map"
-            >
-              <ExternalLinkIcon />
-            </a>
+            <Flex align="center" gap="2" className="shrink-0">
+              <ZoningBadge zoning={parcelZoning[id]} />
+              <a
+                href={parcelMapUrl(id)}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center"
+                style={{ color: "var(--accent-11)" }}
+                title="Open parcel on the Base Units map"
+              >
+                <ExternalLinkIcon />
+              </a>
+            </Flex>
           </Flex>
         ))}
       </Flex>
@@ -123,6 +130,7 @@ const AmendmentView = ({
   // edit-mode parcels + map
   selectedIds,
   parcelAddresses,
+  parcelZoning,
   dissolved,
   onToggleParcel,
   onAddParcel,
@@ -141,6 +149,9 @@ const AmendmentView = ({
   editedBy,
   editedOn,
 }) => {
+  // whether the zoning-districts overlay is shown on the map (both modes)
+  const [showZoning, setShowZoning] = useState(false);
+
   if (!values) {
     return (
       <Flex align="center" justify="center" gap="2" className="p-8">
@@ -154,6 +165,9 @@ const AmendmentView = ({
   const parcelIds = parseParcels(values.parcels);
   const title =
     values.file_number || (mode === "new" ? "New amendment" : "Amendment");
+  const missingRequired = editing
+    ? REQUIRED_FIELDS.filter((n) => String(values[n] ?? "").trim() === "")
+    : [];
 
   return (
     <Flex direction="column" gap="3">
@@ -166,9 +180,21 @@ const AmendmentView = ({
         ) : (
           <span />
         )}
-        <Text size="5" weight="bold" className="text-[#004445]">
-          {title}
-        </Text>
+        <Flex
+          direction="column"
+          align="center"
+          gap="1"
+          style={{ flex: 1, minWidth: 0 }}
+        >
+          <Text size="5" weight="bold" className="text-[#004445]">
+            {title}
+          </Text>
+          {editing && !values.file_number && (
+            <Text size="1" color="gray">
+              File number is assigned automatically on save.
+            </Text>
+          )}
+        </Flex>
         {editing ? (
           <Button
             size="3"
@@ -185,6 +211,13 @@ const AmendmentView = ({
           </Button>
         )}
       </Flex>
+
+      {editing && missingRequired.length > 0 && (
+        <Text size="1" color="gray">
+          Required before saving:{" "}
+          {missingRequired.map((n) => FIELD_BY_NAME[n]?.label || n).join(", ")}.
+        </Text>
+      )}
 
       {editing && status && (
         <Flex
@@ -224,6 +257,7 @@ const AmendmentView = ({
                 <ParcelSelectionPanel
                   selectedIds={selectedIds}
                   parcelAddresses={parcelAddresses}
+                  parcelZoning={parcelZoning}
                   onRemove={onRemoveParcel}
                   onClear={onClearParcels}
                 />
@@ -231,25 +265,43 @@ const AmendmentView = ({
                 <AffectedParcels
                   parcelIds={parcelIds}
                   parcelAddresses={parcelAddresses}
+                  parcelZoning={parcelZoning}
                 />
               )}
             </Box>
             <Box className="flex-1 min-w-0">
               {editing ? (
-                <>
-                  <ZoningMap
-                    selectedIds={selectedIds}
-                    onToggleParcel={onToggleParcel}
-                    dissolved={dissolved}
-                    height={MAP_HEIGHT}
-                  />
-                  <Text size="1" color="gray" className="mt-1 block">
-                    Click parcels to add or remove them. The red outline previews
-                    the dissolved amendment boundary that will be saved.
-                  </Text>
-                </>
+                <ZoningMap
+                  selectedIds={selectedIds}
+                  onToggleParcel={onToggleParcel}
+                  dissolved={dissolved}
+                  showZoning={showZoning}
+                  height={MAP_HEIGHT}
+                />
               ) : (
-                <AmendmentMiniMap geometry={geometry} height={MAP_HEIGHT} />
+                <AmendmentMiniMap
+                  geometry={geometry}
+                  showZoning={showZoning}
+                  height={MAP_HEIGHT}
+                />
+              )}
+              <Flex asChild align="center" gap="2" className="mt-2">
+                <label style={{ cursor: "pointer", width: "fit-content" }}>
+                  <Switch
+                    size="1"
+                    checked={showZoning}
+                    onCheckedChange={setShowZoning}
+                  />
+                  <Text size="1" color="gray">
+                    Show current zoning districts
+                  </Text>
+                </label>
+              </Flex>
+              {editing && (
+                <Text size="1" color="gray" className="mt-1 block">
+                  Click parcels to add or remove them. The red outline previews
+                  the dissolved amendment boundary that will be saved.
+                </Text>
               )}
             </Box>
           </Flex>

--- a/src/Zoning/FieldInput.jsx
+++ b/src/Zoning/FieldInput.jsx
@@ -57,6 +57,11 @@ const FieldInput = ({ field, value, onChange }) => {
     <label>
       <Text as="div" size="1" weight="medium" color="gray" mb="1">
         {field.label}
+        {field.required && (
+          <span style={{ color: "var(--red-9)" }} aria-hidden>
+            {" *"}
+          </span>
+        )}
       </Text>
       {control}
     </label>

--- a/src/Zoning/ParcelSelectionPanel.jsx
+++ b/src/Zoning/ParcelSelectionPanel.jsx
@@ -5,11 +5,13 @@ import {
   ExternalLinkIcon,
 } from "@radix-ui/react-icons";
 import { PARCELS_FIELD_MAX, parcelMapUrl } from "../data/zoning";
+import ZoningBadge from "./ZoningBadge";
 
 // Lists the parcels currently in the amendment grouping.
 const ParcelSelectionPanel = ({
   selectedIds,
   parcelAddresses = {},
+  parcelZoning = {},
   onRemove,
   onClear,
 }) => {
@@ -54,6 +56,7 @@ const ParcelSelectionPanel = ({
                   )}
                 </Flex>
                 <Flex align="center" gap="2" className="shrink-0">
+                  <ZoningBadge zoning={parcelZoning[id]} />
                   <a
                     href={parcelMapUrl(id)}
                     target="_blank"

--- a/src/Zoning/Zoning.jsx
+++ b/src/Zoning/Zoning.jsx
@@ -12,6 +12,7 @@ import { useAuth } from "../contexts/AuthContext";
 import useGroupAccess from "../hooks/useGroupAccess";
 import {
   EDITOR_FIELDS,
+  deriveUniqueId,
   fmtDate,
   fmtDateTime,
   geojsonToZoningGeometry,
@@ -20,6 +21,7 @@ import {
   PARCEL_LAYER_URL,
   PARCELS_FIELD_MAX,
   parseParcels,
+  REQUIRED_FIELDS,
   SORT_OPTIONS,
   sortKey,
   ZONING_FIELDS,
@@ -53,6 +55,7 @@ const Zoning = () => {
   const [detailRecord, setDetailRecord] = useState(null);
   const [detailGeometry, setDetailGeometry] = useState(null);
   const [detailParcelAddresses, setDetailParcelAddresses] = useState({});
+  const [detailParcelZoning, setDetailParcelZoning] = useState({});
   const [detailError, setDetailError] = useState(null);
 
   // edit state
@@ -149,37 +152,44 @@ const Zoning = () => {
     };
   }, [hasAccess, selectedId, token, refreshSignal]);
 
-  // addresses for the viewed record's affected parcels (view mode)
+  // addresses + zoning for the viewed record's affected parcels (view mode)
   useEffect(() => {
     if (editing || !detailRecord) {
       setDetailParcelAddresses({});
+      setDetailParcelZoning({});
       return;
     }
     const ids = parseParcels(detailRecord.parcels);
     if (ids.length === 0) {
       setDetailParcelAddresses({});
+      setDetailParcelZoning({});
       return;
     }
     let cancelled = false;
     queryFeatures({
       url: PARCEL_LAYER_URL,
       where: `${PARCEL_ID_FIELD} IN (${sqlList(ids)})`,
-      outFields: [PARCEL_ID_FIELD, "address"],
+      outFields: [PARCEL_ID_FIELD, "address", "zoning_district"],
       returnGeometry: false,
       authentication: token,
     })
       .then((res) => {
         if (cancelled) return;
-        const map = {};
+        const addresses = {};
+        const zoning = {};
         (res?.features || []).forEach((f) => {
           const pid = f.attributes?.[PARCEL_ID_FIELD];
-          if (pid != null && f.attributes.address) map[pid] = f.attributes.address;
+          if (pid == null) return;
+          if (f.attributes.address) addresses[pid] = f.attributes.address;
+          if (f.attributes.zoning_district) zoning[pid] = f.attributes.zoning_district;
         });
-        setDetailParcelAddresses(map);
+        setDetailParcelAddresses(addresses);
+        setDetailParcelZoning(zoning);
       })
       .catch(() => {
         if (cancelled) return;
         setDetailParcelAddresses({});
+        setDetailParcelZoning({});
       });
     return () => {
       cancelled = true;
@@ -220,11 +230,21 @@ const Zoning = () => {
     return map;
   }, [parcelGeoms]);
 
+  // parcel_id -> zoning designation, from the fetched parcel features
+  const parcelZoning = useMemo(() => {
+    const map = {};
+    Object.entries(parcelGeoms).forEach(([id, feat]) => {
+      const zone = feat?.properties?.zoning_district;
+      if (zone) map[id] = zone;
+    });
+    return map;
+  }, [parcelGeoms]);
+
   const fetchParcelGeom = (parcelId) =>
     queryFeatures({
       url: PARCEL_LAYER_URL,
       where: `${PARCEL_ID_FIELD} = '${String(parcelId).replace(/'/g, "''")}'`,
-      outFields: [PARCEL_ID_FIELD, "address"],
+      outFields: [PARCEL_ID_FIELD, "address", "zoning_district"],
       returnGeometry: true,
       f: "geojson",
       authentication: token,
@@ -338,7 +358,7 @@ const Zoning = () => {
       queryFeatures({
         url: PARCEL_LAYER_URL,
         where: `${PARCEL_ID_FIELD} IN (${sqlList(ids)})`,
-        outFields: [PARCEL_ID_FIELD, "address"],
+        outFields: [PARCEL_ID_FIELD, "address", "zoning_district"],
         returnGeometry: true,
         f: "geojson",
         authentication: token,
@@ -368,9 +388,17 @@ const Zoning = () => {
 
   const parcelsString = selectedIds.join("|");
   const overLimit = parcelsString.length > PARCELS_FIELD_MAX;
-  const canSave = selectedIds.length > 0 && !!dissolved && !overLimit && !saving;
+  const requiredComplete = REQUIRED_FIELDS.every(
+    (name) => String(attributes[name] ?? "").trim() !== ""
+  );
+  const canSave =
+    selectedIds.length > 0 &&
+    !!dissolved &&
+    !overLimit &&
+    !saving &&
+    requiredComplete;
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!canSave) return;
     setSaving(true);
     setStatus(null);
@@ -383,38 +411,71 @@ const Zoning = () => {
     outAttrs.parcels = parcelsString;
 
     const geometry = geojsonToZoningGeometry(dissolved.geometry);
-    const feature =
-      mode === "edit"
-        ? { attributes: { OBJECTID: objectId, ...outAttrs }, geometry }
-        : { attributes: outAttrs, geometry };
-    const op = mode === "edit" ? updateFeatures : addFeatures;
+    const wasNew = mode === "new";
 
-    op({ url: ZONING_LAYER_URL, features: [feature], authentication: token })
-      .then((res) => {
-        const result = (res?.addResults || res?.updateResults || [])[0];
-        if (result?.success) {
-          const newId = result.objectId ?? objectId;
-          const wasNew = mode === "new";
-          setObjectId(newId);
-          setSelectedId(newId);
-          setMode("edit");
-          setStatus({
-            ok: true,
-            message: wasNew ? "Amendment created." : "Changes saved.",
-          });
-          setRefreshSignal((n) => n + 1);
-        } else {
-          setStatus({
-            ok: false,
-            message: result?.error?.description || "Save failed.",
-          });
+    try {
+      let savedId = objectId;
+
+      if (wasNew) {
+        // OBJECTID is unknown until the insert returns…
+        const res = await addFeatures({
+          url: ZONING_LAYER_URL,
+          features: [{ attributes: outAttrs, geometry }],
+          authentication: token,
+        });
+        const result = (res?.addResults || [])[0];
+        if (!result?.success)
+          throw new Error(result?.error?.description || "Save failed.");
+        savedId = result.objectId;
+
+        // …so auto-assign the file number (the CPC unique id) in a follow-up.
+        // Best-effort: the record already exists, so a failure here just leaves
+        // the file number unset (it gets assigned on the next save).
+        const fileNumber = deriveUniqueId({ ...attributes, OBJECTID: savedId });
+        if (fileNumber) {
+          try {
+            await updateFeatures({
+              url: ZONING_LAYER_URL,
+              features: [
+                { attributes: { OBJECTID: savedId, file_number: fileNumber } },
+              ],
+              authentication: token,
+            });
+          } catch (e) {
+            /* record created; file number stays unset until the next save */
+          }
         }
-        setSaving(false);
-      })
-      .catch((err) => {
-        setStatus({ ok: false, message: err?.message || "Save failed." });
-        setSaving(false);
+      } else {
+        // OBJECTID known — assign the file number only if it's not set yet, so
+        // an established number stays stable, then fold it into the update
+        if (!attributes.file_number) {
+          const fileNumber = deriveUniqueId({ ...attributes, OBJECTID: objectId });
+          if (fileNumber) outAttrs.file_number = fileNumber;
+        }
+        const res = await updateFeatures({
+          url: ZONING_LAYER_URL,
+          features: [{ attributes: { OBJECTID: objectId, ...outAttrs }, geometry }],
+          authentication: token,
+        });
+        const result = (res?.updateResults || [])[0];
+        if (!result?.success)
+          throw new Error(result?.error?.description || "Save failed.");
+        savedId = result.objectId ?? objectId;
+      }
+
+      setObjectId(savedId);
+      setSelectedId(savedId);
+      setMode("edit");
+      setStatus({
+        ok: true,
+        message: wasNew ? "Amendment created." : "Changes saved.",
       });
+      setRefreshSignal((n) => n + 1);
+    } catch (err) {
+      setStatus({ ok: false, message: err?.message || "Save failed." });
+    } finally {
+      setSaving(false);
+    }
   };
 
   // ---- access gating ----
@@ -491,6 +552,7 @@ const Zoning = () => {
               geometry={detailGeometry}
               selectedIds={selectedIds}
               parcelAddresses={editing ? parcelAddresses : detailParcelAddresses}
+              parcelZoning={editing ? parcelZoning : detailParcelZoning}
               dissolved={dissolved}
               onToggleParcel={handleToggleParcel}
               onAddParcel={handleAddParcel}

--- a/src/Zoning/ZoningBadge.jsx
+++ b/src/Zoning/ZoningBadge.jsx
@@ -1,0 +1,31 @@
+import { Text } from "@radix-ui/themes";
+import { ZONING_ZONES_BY_KEY } from "../data/zoningZones";
+
+// Small colored chip showing a parcel's zoning designation (e.g. "R2"),
+// colored to match the zoning-districts map overlay / legend. Renders nothing
+// when the parcel has no zoning on record.
+const ZoningBadge = ({ zoning }) => {
+  if (!zoning) return null;
+  const zone = ZONING_ZONES_BY_KEY[zoning];
+  return (
+    <Text
+      size="1"
+      title={zone ? `${zoning} — ${zone.name}` : zoning}
+      style={{
+        flexShrink: 0,
+        backgroundColor: zone?.color || "#e5e7eb",
+        color: zone?.textColor || "#222",
+        border: "1px solid rgba(0,0,0,0.15)",
+        borderRadius: 4,
+        padding: "0 6px",
+        lineHeight: "18px",
+        fontWeight: 600,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {zoning}
+    </Text>
+  );
+};
+
+export default ZoningBadge;

--- a/src/Zoning/ZoningMap.jsx
+++ b/src/Zoning/ZoningMap.jsx
@@ -2,14 +2,25 @@ import { useEffect, useRef, useState } from "react";
 import maplibregl from "maplibre-gl";
 import bbox from "@turf/bbox";
 import { baseStyle } from "../styles/mapstyle.js";
+import {
+  addZoningDistrictsLayers,
+  setZoningDistrictsVisible,
+} from "./zoningOverlay";
 
 // Map for selecting parcels into a zoning-amendment grouping.
 // - click a parcel to toggle it in/out of the selection (fine control)
 // - selected parcels are highlighted via a vector-tile filter on `parcel_id`
 // - the dissolved amendment boundary is previewed as an outline
+// - an optional zoning-districts overlay (`showZoning`) shows current zoning
 const SELECTION_COLOR = "#2563eb";
 
-const ZoningMap = ({ selectedIds, onToggleParcel, dissolved, height = "65vh" }) => {
+const ZoningMap = ({
+  selectedIds,
+  onToggleParcel,
+  dissolved,
+  showZoning = false,
+  height = "65vh",
+}) => {
   const [theMap, setTheMap] = useState(null);
   // keep the latest toggle callback so the click handler isn't stale
   const toggleRef = useRef(onToggleParcel);
@@ -39,6 +50,10 @@ const ZoningMap = ({ selectedIds, onToggleParcel, dissolved, height = "65vh" }) 
           [14.1, 0.2],
         ],
       });
+
+      // zoning-districts overlay (hidden until toggled on) — added before the
+      // selection/dissolved layers so those highlights stay on top of it
+      addZoningDistrictsLayers(map);
 
       // highlight fill for selected parcels (filtered by parcel_id)
       map.addLayer({
@@ -92,12 +107,29 @@ const ZoningMap = ({ selectedIds, onToggleParcel, dissolved, height = "65vh" }) 
       }
     });
 
-    // pointer cursor over parcels
-    map.on("mouseenter", "parcel-fill", () => {
+    // hover tooltip: parcel id · address · zoning (all carried on the tiles)
+    const popup = new maplibregl.Popup({
+      closeButton: false,
+      closeOnClick: false,
+      offset: 8,
+      className: "zoning-parcel-tip",
+    });
+    map.on("mousemove", "parcel-fill", (e) => {
+      const props = e.features?.[0]?.properties;
+      const pid = props?.parcel_id;
+      if (!pid) {
+        popup.remove();
+        return;
+      }
       map.getCanvas().style.cursor = "pointer";
+      const text = [pid, props.address, props.zoning_district]
+        .filter(Boolean)
+        .join(" · ");
+      popup.setLngLat(e.lngLat).setText(text).addTo(map);
     });
     map.on("mouseleave", "parcel-fill", () => {
       map.getCanvas().style.cursor = "";
+      popup.remove();
     });
 
     return () => map.remove();
@@ -110,6 +142,25 @@ const ZoningMap = ({ selectedIds, onToggleParcel, dissolved, height = "65vh" }) 
     theMap.setFilter("zoning-selection-fill", filter);
     theMap.setFilter("zoning-selection-line", filter);
   }, [theMap, selectedIds]);
+
+  // show/hide the zoning-districts overlay; when on, fade the selection fill to
+  // a faint gray so the district color shows through selected parcels
+  useEffect(() => {
+    if (!theMap) return;
+    setZoningDistrictsVisible(theMap, showZoning);
+    if (theMap.getLayer("zoning-selection-fill")) {
+      theMap.setPaintProperty(
+        "zoning-selection-fill",
+        "fill-color",
+        showZoning ? "#6b7280" : SELECTION_COLOR
+      );
+      theMap.setPaintProperty(
+        "zoning-selection-fill",
+        "fill-opacity",
+        showZoning ? 0.1 : 0.35
+      );
+    }
+  }, [theMap, showZoning]);
 
   // update the dissolved preview; fit to it once (no animation), not on every change
   const didFitRef = useRef(false);

--- a/src/Zoning/zoningOverlay.js
+++ b/src/Zoning/zoningOverlay.js
@@ -1,0 +1,86 @@
+import {
+  ZONING_MATCH_PROPERTY,
+  zoningFillColorExpression,
+} from "../data/zoningZones";
+
+// Shared Detroit zoning-districts overlay for the amendment maps. Mirrors the
+// Atlas "zoning" theme source so the district colors match across the app
+// (see src/data/atlas.js / zoningZones.js).
+const ZONING_TILES = [
+  "https://tiles.arcgis.com/tiles/qvkbeam7Wirps6zC/arcgis/rest/services/Zoning_Vector_Tiles/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+];
+const ZONING_SOURCE_LAYER = "Zoning";
+
+export const ZONING_DISTRICT_LAYER_IDS = [
+  "zoning-districts-fill",
+  "zoning-districts-line",
+  "zoning-districts-label",
+];
+
+// Add the (initially hidden) zoning-districts source + fill/line layers to a
+// map. Call from the map's "load" handler, before any layers that should sit
+// on top of the districts (parcel highlights, the saved amendment polygon).
+export const addZoningDistrictsLayers = (map) => {
+  if (map.getSource("zoning-districts")) return;
+  map.addSource("zoning-districts", {
+    type: "vector",
+    tiles: ZONING_TILES,
+    maxzoom: 19,
+  });
+  map.addLayer({
+    id: "zoning-districts-fill",
+    type: "fill",
+    source: "zoning-districts",
+    "source-layer": ZONING_SOURCE_LAYER,
+    layout: { visibility: "none" },
+    paint: {
+      "fill-color": zoningFillColorExpression(),
+      "fill-opacity": 0.45,
+    },
+  });
+  map.addLayer({
+    id: "zoning-districts-line",
+    type: "line",
+    source: "zoning-districts",
+    "source-layer": ZONING_SOURCE_LAYER,
+    layout: { visibility: "none" },
+    paint: {
+      "line-color": "#6e6e6e",
+      "line-width": 0.4,
+      "line-opacity": 0.6,
+    },
+  });
+  // subtle per-district designation labels (e.g. "R2"), only when zoomed in
+  map.addLayer({
+    id: "zoning-districts-label",
+    type: "symbol",
+    source: "zoning-districts",
+    "source-layer": ZONING_SOURCE_LAYER,
+    minzoom: 14,
+    layout: {
+      visibility: "none",
+      "text-field": ["coalesce", ["get", ZONING_MATCH_PROPERTY], ""],
+      "text-font": ["Montserrat SemiBold"],
+      "text-size": 13,
+      "text-padding": 8,
+      "text-allow-overlap": false,
+      "text-optional": true,
+    },
+    paint: {
+      "text-color": "#27272a",
+      "text-opacity": 0.6,
+      "text-halo-color": "rgba(255,255,255,0.9)",
+      "text-halo-width": 1.4,
+    },
+  });
+};
+
+// Show or hide the zoning-districts overlay on a map.
+export const setZoningDistrictsVisible = (map, visible) => {
+  const visibility = visible ? "visible" : "none";
+  ZONING_DISTRICT_LAYER_IDS.forEach((id) => {
+    if (map.getLayer(id)) {
+      map.setLayoutProperty(id, "visibility", visibility);
+    }
+  });
+};

--- a/src/data/zoning.js
+++ b/src/data/zoning.js
@@ -36,6 +36,16 @@ export const ZONING_OPTIONS = [
   "MKT", "TM", "W1",
 ];
 
+// Planners an amendment can be assigned to (issue #7964 picklist).
+export const ASSIGNED_TO_OPTIONS = [
+  "Kimani Jeffrey",
+  "Rory Bolger",
+  "Eric Fazzini",
+  "Christopher Gulock",
+  "Jamie Murphy",
+  "Timarie DeBruhl",
+];
+
 // Editable attribute fields, in display order, with input types.
 // type: "text" | "textarea" | "date" | "select" | "combobox"
 export const ZONING_FIELDS = [
@@ -45,12 +55,18 @@ export const ZONING_FIELDS = [
     name: "application_type",
     label: "Application type",
     type: "select",
-    options: ["Rezoning", "PD / PC / PCA Zoning Change", "Map Amendment"],
+    options: ["Rezoning", "PD / PC / PCA Zoning Change"],
+    required: true,
   },
   { name: "application_description", label: "Description", type: "textarea" },
   { name: "received_date", label: "Received date", type: "date" },
   { name: "check_number", label: "Check number", type: "text" },
-  { name: "assigned_to", label: "Assigned to", type: "text" },
+  {
+    name: "assigned_to",
+    label: "Assigned to",
+    type: "select",
+    options: ASSIGNED_TO_OPTIONS,
+  },
   {
     name: "current_zoning",
     label: "Current zoning",
@@ -85,7 +101,6 @@ export const ZONING_FIELDS = [
     options: ["Approve", "Deny"],
   },
   { name: "cpc_refer_to_council_date", label: "CPC refer to council date", type: "date" },
-  { name: "council_hearing_1_date", label: "Council hearing 1 date", type: "date" },
   { name: "ped_public_hearing_date", label: "PED public hearing date", type: "date" },
   {
     name: "ped_recommendation",
@@ -110,18 +125,18 @@ export const FIELD_BY_NAME = Object.fromEntries(
   ZONING_FIELDS.map((f) => [f.name, f])
 );
 
+// Field names that must be filled before an amendment can be saved.
+export const REQUIRED_FIELDS = ZONING_FIELDS.filter((f) => f.required).map(
+  (f) => f.name
+);
+
 // Detail fields grouped by workflow stage (application_type & description are
 // shown in the map block, so they're omitted here).
 export const FIELD_GROUPS = [
   {
+    // file_number is the record's title, edited from the header (see AmendmentView).
     title: "Intake",
-    fields: [
-      "file_number",
-      "petition_number",
-      "received_date",
-      "check_number",
-      "assigned_to",
-    ],
+    fields: ["petition_number", "received_date", "check_number", "assigned_to"],
   },
   {
     title: "Zoning",
@@ -144,7 +159,7 @@ export const FIELD_GROUPS = [
   },
   {
     title: "City Council",
-    fields: ["council_hearing_1_date", "council_action_date", "council_action"],
+    fields: ["council_action_date", "council_action"],
   },
 ];
 
@@ -222,6 +237,28 @@ export const sortKey = (value, kind) => {
     return typeof value === "number" ? value : Date.parse(value) || 0;
   }
   return String(value).toLowerCase();
+};
+
+// Application-type prefixes for the derived unique id (issue #7964).
+export const APPLICATION_TYPE_ID_PREFIX = {
+  Rezoning: "R",
+  "PD / PC / PCA Zoning Change": "P",
+};
+
+// Derived, display-only unique identifier for an amendment (issue #7964):
+//   CPC-R-<year>-<OBJECTID>  rezonings
+//   CPC-P-<year>-<OBJECTID>  PD / PC / PCA zoning changes
+// Year prefers `application_year`, falling back to the received-date year.
+// Returns "" when it can't be formed (no prefix, no year, or unsaved record).
+export const deriveUniqueId = (rec) => {
+  if (!rec) return "";
+  const prefix = APPLICATION_TYPE_ID_PREFIX[rec.application_type];
+  const year =
+    rec.application_year ||
+    (rec.received_date ? fmtDate(rec.received_date).slice(0, 4) : "");
+  const oid = rec.OBJECTID;
+  if (!prefix || !year || oid == null || oid === "") return "";
+  return `CPC-${prefix}-${year}-${oid}`;
 };
 
 // Derive a human "status" from the furthest-along workflow field.

--- a/src/data/zoningZones.js
+++ b/src/data/zoningZones.js
@@ -1,0 +1,115 @@
+// Detroit zoning district reference data — ported from the atlas-detroit
+// `src/content/legends/zones.yaml` legend (key, group, name, color, textColor,
+// description), with the `MKT` (Market & Distribution) district added since the
+// districts service publishes it but the source YAML omitted it.
+//
+// This drives the Atlas "zoning" theme end to end: the per-district map colors,
+// the grouped legend, the zone-explorer panel, and the click popups.
+//
+// Matching: the map fill is colored from the vector tile's `ZONING_REV`
+// attribute, which carries the district designation (R1, B4, SD4, MKT, ...).
+// The districts *view* exposes the same value as `zoning_designation`.
+
+export const ZONING_MATCH_PROPERTY = "ZONING_REV"; // vector tile attribute
+export const ZONING_VIEW_FIELD = "zoning_designation"; // districts view attribute
+
+// Display order of the district groups.
+export const ZONING_GROUP_ORDER = [
+  "Residential",
+  "Business",
+  "Industrial",
+  "Special Purpose",
+];
+
+export const ZONING_ZONES = [
+  // Residential
+  { key: "R1", group: "Residential", name: "Single-Family Residential District", color: "#FCF3CF", textColor: "#222", description: "This district is designed to protect and preserve quiet, low-density residential areas with single-family detached dwellings." },
+  { key: "R2", group: "Residential", name: "Two-Family Residential District", color: "#F9E79F", textColor: "#222", description: "The district is designed to protect and enhance areas developed with single- or two-family dwellings." },
+  { key: "R3", group: "Residential", name: "Low Density Residential District", color: "#F4D03F", textColor: "#222", description: "This district is designed as a low-density multi-family district for town houses, courts, and garden apartments." },
+  { key: "R4", group: "Residential", name: "Thoroughfare Residential District", color: "#F1C40F", textColor: "#222", description: "This district is designed for low-medium density residential dwellings on major or secondary thoroughfares." },
+  { key: "R5", group: "Residential", name: "Medium Density Residential District", color: "#D4AC0D", textColor: "#222", description: "This district provides for a range of residential development from single-family to medium-density multiple-family dwellings." },
+  { key: "R6", group: "Residential", name: "High Density Residential District", color: "#B7950B", textColor: "#222", description: "The district is designed as a high-density multiple-dwellings district adjacent to major centers." },
+
+  // Business
+  { key: "B1", group: "Business", name: "Restricted Business District", color: "#F1948A", textColor: "#222", description: "The B1 District is designed to provide an adequately controlled transition in land use from residential to business and commercial uses." },
+  { key: "B2", group: "Business", name: "Local Business and Residential District", color: "#EC7063", textColor: "#222", description: "The B2 Local Business and Residential District provides for the day-to-day consumer goods and services required to serve a small residential area." },
+  { key: "B3", group: "Business", name: "Shopping District", color: "#E74C3C", textColor: "#222", description: "The B3 Shopping District provides for a range of convenience and comparison shopping goods stores." },
+  { key: "B4", group: "Business", name: "General Business District", color: "#A93226", textColor: "#DDD", description: "The B4 General Business District provides for business and commercial uses of a thoroughfare-oriented nature." },
+  { key: "B5", group: "Business", name: "Major Business District", color: "#922B21", textColor: "#DDD", description: "This district is designed to provide adequate regulations within the Central business district and the New Center Area." },
+  { key: "B6", group: "Business", name: "General Services District", color: "#7B241C", textColor: "#DDD", description: "This district provides for wholesaling, transport, food services, and similar activities essential to the commerce and health of the City." },
+
+  // Industrial
+  { key: "M1", group: "Industrial", name: "Limited Industrial District", color: "#EBDEF0", textColor: "#222", description: "This district is used primarily along major and secondary thoroughfares in blocks which contain older, vacant structures or mixed land uses." },
+  { key: "M2", group: "Industrial", name: "Restricted Industrial District", color: "#C39BD3", textColor: "#222", description: "This district is designed for a wide range of industrial and related uses which can function with a minimum of undesirable effects." },
+  { key: "M3", group: "Industrial", name: "General Industrial District", color: "#9B59B6", textColor: "#222", description: "This district is composed of property so situated as to be suitable for industrial development." },
+  { key: "M4", group: "Industrial", name: "Intensive Industrial District", color: "#7D3C98", textColor: "#DDD", description: "This district will permit uses which are usually objectionable and is rarely located adjacent to residential districts." },
+  { key: "M5", group: "Industrial", name: "Special Industrial District", color: "#4A235A", textColor: "#DDD", description: "This district is composed primarily of property located deep within other industrial districts for intensive uses." },
+
+  // Special Purpose
+  { key: "P1", group: "Special Purpose", name: "Open Parking District", color: "#CCD1D1", textColor: "#222", description: "This district is designed for off-street parking of private passenger vehicles." },
+  { key: "PC", group: "Special Purpose", name: "Public Center District", color: "#884EA0", textColor: "#DDD", description: "This district includes areas used for governmental, recreational, and cultural purposes of civic importance." },
+  { key: "PCA", group: "Special Purpose", name: "Restricted Central Business District", color: "#2471A3", textColor: "#DDD", description: "The Public Center Adjacent District includes property in close proximity to the Public Center District." },
+  { key: "PD", group: "Special Purpose", name: "Planned Development District", color: "#3498DB", textColor: "#222", description: "This district will permit planned developments throughout the City, particularly useful in urban renewal areas." },
+  { key: "PR", group: "Special Purpose", name: "Parks and Recreation", color: "#1E8449", textColor: "#DDD", description: "The intent is to retain publicly owned lands in excess of four acres for recreational uses or open space." },
+  { key: "SD1", group: "Special Purpose", name: "Special Development District - Small Scale, Mixed Use", color: "#D4E6F1", textColor: "#222", description: "This district encourages a complementary mixture of small-scale, pedestrian- and transit-oriented uses." },
+  { key: "SD2", group: "Special Purpose", name: "Special Development District - Mixed Use", color: "#7FB3D5", textColor: "#222", description: "This district encourages more intensive pedestrian- and transit-oriented uses for neighborhood centers." },
+  { key: "SD3", group: "Special Purpose", name: "Special Development District - Technology & Research", color: "#D7BDE2", textColor: "#222", description: "The SD3 District is designed for research facility development in a campus-like setting." },
+  { key: "SD4", group: "Special Purpose", name: "Special Development District - Riverfront Mixed Use", color: "#45B39D", textColor: "#222", description: "The SD4 District is intended for high intensity residential and commercial mixed-use development on the Riverfront." },
+  { key: "SD5", group: "Special Purpose", name: "Special Development District - Casinos", color: "#ff8f00", textColor: "#222", description: "The SD5 District facilitates the location of licensed casinos and casino complexes." },
+  { key: "TM", group: "Special Purpose", name: "Transitional - Industrial", color: "#A2D9CE", textColor: "#222", description: "This district covers areas with mixed uses transitioning to industrial uses." },
+  { key: "W1", group: "Special Purpose", name: "Waterfront - Industrial", color: "#82E0AA", textColor: "#222", description: "This district provides for water-oriented uses on limited waterfront property." },
+  { key: "MKT", group: "Special Purpose", name: "Market and Distribution District", color: "#E59866", textColor: "#222", description: "The MKT District provides for market, wholesale, and distribution activities, such as those in and around Eastern Market." },
+];
+
+export const ZONING_ZONES_BY_KEY = Object.fromEntries(
+  ZONING_ZONES.map((z) => [z.key, z])
+);
+
+// Zones grouped for the explorer panel, in ZONING_GROUP_ORDER.
+export const ZONING_GROUPS = ZONING_GROUP_ORDER.map((group) => ({
+  group,
+  zones: ZONING_ZONES.filter((z) => z.group === group),
+}));
+
+// MapLibre data-driven fill color: one color per district designation, matched
+// on the vector tile's ZONING_REV value. Built from ZONING_ZONES so it never
+// drifts from the legend/popups.
+export const zoningFillColorExpression = () => [
+  "match",
+  ["to-string", ["coalesce", ["get", ZONING_MATCH_PROPERTY], ""]],
+  ...ZONING_ZONES.flatMap((z) => [z.key, z.color]),
+  "#d9d9d9", // unclassified / unknown designation
+];
+
+const escapeHtml = (v) =>
+  String(v ?? "").replace(/[&<>"]/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c])
+  );
+
+// Rich click popup: designation + group + full district name + description,
+// looked up from the curated zone data (falling back to the view's own fields).
+export const renderZoningPopup = (attrs) => {
+  const key = attrs?.[ZONING_VIEW_FIELD] ?? "";
+  const zone = ZONING_ZONES_BY_KEY[key];
+  const name = zone?.name || attrs?.zoning_description || "";
+  const group = zone?.group || "";
+  const description = zone?.description || attrs?.zoning_description || "";
+  const swatch = zone?.color || "#d9d9d9";
+
+  if (!key && !name) {
+    return `<div style="font-size:12px;color:#6b7280">No zoning district here</div>`;
+  }
+
+  return `
+    <div style="font-size:12px;line-height:1.45;max-width:260px">
+      <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">
+        <span style="width:13px;height:13px;border-radius:2px;background:${swatch};border:1px solid rgba(0,0,0,.25);flex-shrink:0"></span>
+        <span style="font-weight:700">${escapeHtml(key)}</span>
+        ${group ? `<span style="color:#6b7280">· ${escapeHtml(group)}</span>` : ""}
+      </div>
+      ${name ? `<div style="font-weight:600;margin-bottom:3px">${escapeHtml(name)}</div>` : ""}
+      ${description ? `<div style="color:#374151">${escapeHtml(description)}</div>` : ""}
+    </div>`;
+};
+
+export default ZONING_ZONES;


### PR DESCRIPTION
Implements the front-end items from #7964 (map improvements + field updates), plus supporting UX.

## Map
- **Zoning-districts overlay toggle** on both the edit (parcel-selection) map and the read-only mini-map — a control just below each map. *(#7964: toggle on/off zoning map)*
- **Per-parcel zoning in the sidebar** — colored zoning chips on both the "Selected parcels" (edit) and "Affected parcels" (view) lists. *(#7964: show parcel zoning in selected parcels preview)*
- **Subtle district labels** (Montserrat SemiBold, faint, z14+) shown with the overlay.
- **Hover tooltips** on both maps show `parcel id · address · zoning`, read straight off the parcel vector tiles — so it works for every parcel, no per-parcel query.
- When the overlay is on, the amendment-area fill fades to faint gray so the district colors read through (the outline still marks the boundary).

## Fields
- **Auto-assigned file number** = the CPC unique id, written into `file_number` on save: `CPC-R-<year>-<OBJECTID>` for rezonings, `CPC-P-<year>-<OBJECTID>` for PD/PC/PCA. Assigned once (stable) and shown read-only as the record title.
- **`assigned_to` → picklist** of the six planners.
- **`application_type` required** (red asterisk + save gating); removed the "Map Amendment" option.
- **Removed `council_hearing_1_date`** (deleted on the layer).

## Not included yet
- The four new columns (ordinance year/number, enactment date, application year) and requiring/prefilling `application_year` — these need the authenticated layer field names. Until `application_year` is wired, the file-number year falls back to `received_date`.
- Auto-assign is **assign-once** (a set file number is left stable). Retrofit happens on edit for records with no file number; a bulk overwrite of existing manual numbers would be a separate data migration.

## Note
Includes `src/data/zoningZones.js` (zoning reference data). It's standalone with no Atlas dependency; the Atlas theme is intentionally **not** part of this PR.

Refs #7964
